### PR TITLE
Revising second set of 19 datasheets in scs/en

### DIFF
--- a/cv-corpus/scs/23.0-2025-09-17/final/en/kw.md
+++ b/cv-corpus/scs/23.0-2025-09-17/final/en/kw.md
@@ -8,19 +8,19 @@ speech (13 hours validated) from 10 speakers.
 
 Cornish, or Kernewek, is a Brythonic language, alongside Breton and Welsh, and part of the Celtic Indo-European language family. It is an indigenous language of the United Kingdom, with most speakers located in Cornwall. In the 2021 UK Census 567 people self-identified Cornish as their main language. UNESCO has classified its status as "severely endangered".
 
-### Variants 
+<!-- ### Variants -->
+<!-- Original Answer: -->
+<!-- There are currently no variants defined for Cornish. -->
 
-There are currently no variants defined for Cornish.
+<!-- ### Accents -->
 
-### Accents
+<!-- #### Predefined -->
 
-#### Predefined
+<!-- There are currently no pre-defined accents. -->
 
-There are currently no pre-defined accents.
+<!-- #### User defined -->
 
-#### User defined
-
-There are currently no user-defined accents.
+<!-- There are currently no user-defined accents. -->
 
 ## Demographic information
 <!-- You can get a lot of the information in this section from https://analyzer.cv-toolbox.web.tr/browse -->
@@ -30,36 +30,20 @@ The dataset includes the following distribution of age and gender.
 
 Self-declared gender information, frequency refers to the number of clips annotated with this gender.
 
-| Gender | Frequency |
-|--------|-----------|
-| male, masculine | 0 |
-| female, feminine | 3,550 |
-| undeclared | 5,807 |
-
 ### Age
 
 Self-declared age information, frequency refers to the number of clips annotated with this age band.
-
-| Age band | Frequency |
-|----------|-----------|
-| teens | 0 |
-| twenties | 0 |
-| thirties | 0 |
-| fourties | 3,540 |
-| fifties | 3,778 |
-| sixties | 241 |
-| seventies | 496 |
-| undeclared | 1,302 |
 
 ## Text corpus
 
 The dataset contains **10.8 validated hours** of speech from **10** unique
 contributors.
-| Type                |   Count | Hours |
-| ------------------- | ------: | ----: |
-| Validated Clips     |   9,357 |  10.8 |
-| Invalidated Clips   |     0 |  0.00 |
-| **Total Clips**     |   9,357 |  10.8 |
+
+| Type                | Count   | Hours |
+|---------------------|---------|-------|
+| Validated Clips     | 9,357   |  10.8 |
+| Invalidated Clips   | 0       |  0.00 |
+| **Total Clips**     | 9,357   |  10.8 |
 
 *   **Average sentence length (tokens):** 6.4
 *   **Average sentence length (characters):** 31
@@ -70,18 +54,19 @@ Cornish has several writing systems in place. The majority of this dataset uses 
 
 #### Symbol table
 
-The dataset uses the following characters: `' -   ! , . ? a b c d e f g h i j k l m n o p r s t u v w x y z`
+The dataset uses the following characters: 
+```' -   ! , . ? a b c d e f g h i j k l m n o p r s t u v w x y z```
 
 ### Sample
 
 There follows a randomly selected sample of five sentences from the corpus.
-
-*   A yllyn ni redya hemma?
-*   Marthys ens i.
-*   Esos. Yth esos ta ena y'n kornel.
-*   A wrussyn ni diwrosa yn uskis?
-*   Dha leveryans yw nebes da.
-
+```
+A yllyn ni redya hemma?
+Marthys ens i.
+Esos. Yth esos ta ena y'n kornel.
+A wrussyn ni diwrosa yn uskis?
+Dha leveryans yw nebes da.
+```
 ### Sources
 
 The text for this dataset comes from the following sources:
@@ -110,7 +95,7 @@ The text for this dataset comes from the following sources:
 
 ### Datasheet authors
 
-Sam Rogerson <cornishlanguage@cornwall.gov.uk>
+* Sam Rogerson <cornishlanguage@cornwall.gov.uk>
 
 ### Funding
 

--- a/cv-corpus/scs/23.0-2025-09-17/final/en/kxp.md
+++ b/cv-corpus/scs/23.0-2025-09-17/final/en/kxp.md
@@ -7,14 +7,15 @@ speech (12 hours validated) from 22 speakers.
 <!-- {{LANGUAGE_DESCRIPTION}} -->
 <!-- Provide a brief (1-2 paragraph) description of your language -->
 
-The thradhri language is speaking in various sindh Pakistan, total 1.1 million people's who speak the thradhri language. It is from Thraad province of India. 
+The Thradhri language is speaking in various Sindh Pakistan, total 1.1 million people's who speak the Thradhri language. It is from Thraad province of India. 
 
-### Variants
+<!-- ### Variants -->
 <!-- {{VARIANT_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Describe the variants (MCV variants) of your language -->
 
-Parkari, Dhatti, Gujarati, Wadiyaari and marwari
+<!-- Original Answer: -->
+<!-- Parkari, Dhatti, Gujarati, Wadiyaari and marwari -->
 
 ## Demographic information
 <!-- You can get a lot of the information in this section from https://analyzer.cv-toolbox.web.tr/browse -->
@@ -62,56 +63,20 @@ Arabi parssion keyboard
 <!-- @ OPTIONAL @ -->
 <!-- If the writing system is alphabetic, you can include the valid alphabet here -->
 
-ا - ی
+```ا - ی```
 
 ### Sample
 <!-- {{SENTENCES_SAMPLE}} -->
 There follows a randomly selected sample of five sentences from the corpus.
-1. My name is Nanjit 2. I live in Mirpurkhas. I am married. 3.I have four children 4. My father is driver. I love to my family. 5. My chil
-
-### Sources
-<!-- {{SOURCES_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- A list of sentence sources, can be curated to the top-N -->
-
-
-
-### Text domains
-<!-- {{TEXT_DOMAIN_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- What text domains are represented in the corpus? -->
-
-
-
-### Processing
-<!-- {{PROCESSING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- How has the text data been processed -->
-
-
-
-### Recommended post-processing
-<!-- {{RECOMMENDED_POSTPROCESSING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- What should people do before they use the data, for example Unicode normalisation -->
-
-
+```
+1. My name is Nanjit 
+2. I live in Mirpurkhas. I am married. 
+3. I have four children 
+4. My father is driver. I love to my family. 
+5. My chil
+```
 
 ## Get involved!
-
-
-### Community links
-<!-- {{COMMUNITY_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Links to community chats / fora -->
-
-
-
-### Discussions
-<!-- {{DISCUSSION_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Any links to discussions, for example on Discourse or other fora or blogs can be included here -->
-
 
 
 ### Contribute
@@ -127,13 +92,7 @@ There follows a randomly selected sample of five sentences from the corpus.
 <!-- {{DATASHEET_AUTHORS_LIST}} -->
 <!-- A list in the format of: Your Name <email@email.com> -->
 
-
-
-### Citation guidelines
-<!-- {{CITATION_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- If you published a paper and would like people to cite it, you can include the BiBTeX here -->
-
+Common Voice Community
 
 
 ### Funding

--- a/cv-corpus/scs/23.0-2025-09-17/final/en/lrk.md
+++ b/cv-corpus/scs/23.0-2025-09-17/final/en/lrk.md
@@ -7,14 +7,16 @@ speech (12 hours validated) from 20 speakers.
 <!-- {{LANGUAGE_DESCRIPTION}} -->
 <!-- Provide a brief (1-2 paragraph) description of your language -->
 
-Five lake Plus
+Loarki is spoken by around 520,000 people in Sindh in Pakistan and in Rajasthan in India.
 
-### Variants
+<!-- ### Variants -->
 <!-- {{VARIANT_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Describe the variants (MCV variants) of your language -->
 
-مارواڑی،سنسکرت،سندھی۔اردو
+<!-- Original Answer: -->
+<!-- مارواڑی،سنسکرت،سندھی۔اردو -->
+
 
 ## Demographic information
 <!-- You can get a lot of the information in this section from https://analyzer.cv-toolbox.web.tr/browse -->
@@ -48,7 +50,7 @@ Self-declared age information, frequency refers to the number of clips annotated
 <!-- @ OPTIONAL @ -->
 <!-- An overview of the text corpus, with information such as average length (in characters and words) of validated sentences. -->
 
-دو ھزار جملے لوھار کی زبان کے ھی اور کچھ گھریلو اور کہانیوں  والی ھی 
+<!-- دو ھزار جملے لوھار کی زبان کے ھی اور کچھ گھریلو اور کہانیوں  والی ھی -->
 
 ### Writing system
 <!-- {{WRITING_SYSTEM_DESCRIPTION}} -->
@@ -62,12 +64,14 @@ Latin Sindhi
 <!-- @ OPTIONAL @ -->
 <!-- If the writing system is alphabetic, you can include the valid alphabet here -->
 
-اآب ٻ ڀ ت ٿ ٺ ث ٽ ج ڄ چ ڇ خ ح د ڌ ڏ ڊ ذ ر ڙ ز س ش ص ض ط ظ ع غ ف ڦ ڪ و ک ل م ن ڻ و ه ھ ي
+```اآب ٻ ڀ ت ٿ ٺ ث ٽ ج ڄ چ ڇ خ ح د ڌ ڏ ڊ ذ ر ڙ ز س ش ص ض ط ظ ع غ ف ڦ ڪ و ک ل م ن ڻ و ه ھ ي```
 
 ### Sample
 <!-- {{SENTENCES_SAMPLE}} -->
-There follows a randomly selected sample of five sentences from the corpus.
+There follows a randomly selected sample of sentences from the corpus.
+```
 ھون لوھار ھون ماري ذات پتاڻي جي ھون بي روزگار ھون  ماري تين ٽاٻر ھي ماري ٻير گهر ۾ گهي ھي
+```
 
 ### Sources
 <!-- {{SOURCES_LIST}} -->
@@ -83,42 +87,13 @@ Nand kishore
 
 General
 
-### Processing
-<!-- {{PROCESSING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- How has the text data been processed -->
-
-Software 
-
-### Recommended post-processing
-<!-- {{RECOMMENDED_POSTPROCESSING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- What should people do before they use the data, for example Unicode normalisation -->
-
-No
 
 ## Get involved!
 
 
-### Community links
-<!-- {{COMMUNITY_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Links to community chats / fora -->
-
-No
-
-### Discussions
-<!-- {{DISCUSSION_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Any links to discussions, for example on Discourse or other fora or blogs can be included here -->
-
-No
-
 ### Contribute
 <!-- {{CONTRIBUTE_LINKS_LIST}} -->
 <!-- Here you can include links for how to contribute to the dataset -->
-
-No
 
 ## Acknowledgements
 
@@ -127,14 +102,8 @@ No
 <!-- {{DATASHEET_AUTHORS_LIST}} -->
 <!-- A list in the format of: Your Name <email@email.com> -->
 
-No
+Common Voice Community
 
-### Citation guidelines
-<!-- {{CITATION_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- If you published a paper and would like people to cite it, you can include the BiBTeX here -->
-
-No
 
 ### Funding
 <!-- {{FUNDING_DESCRIPTION}} -->

--- a/cv-corpus/scs/23.0-2025-09-17/final/en/mcf.md
+++ b/cv-corpus/scs/23.0-2025-09-17/final/en/mcf.md
@@ -9,12 +9,15 @@ speech (11 hours validated) from 20 speakers.
 <!-- {{LANGUAGE_DESCRIPTION}} -->
 <!-- Provide a brief (1-2 paragraph) description of your language -->
 The [Matsés](https://bdpi.cultura.gob.pe/lenguas/matses) language, ISO code [mcf](https://www.ethnologue.com/language/mcf/) belongs to the Pano family and is spoken in the basins of the Gálvez and Yaquirana rivers, and in the Añushiyacu creek, in the Loreto department of Peru. It has also traditionally been known as "mayuruna", although today the speakers themselves prefer to call it Matsés.
-### Variants 
+
+
+<!-- ### Variants -->
 
 <!-- {{VARIANT_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Describe the variants (MCV variants) of your language -->
-It is also spoken in Brasil close to the Yavarí river which is the borderline between Perú and Brasil. 
+<!-- Original Answer: -->
+<!-- It is also spoken in Brasil close to the Yavarí river which is the borderline between Perú and Brasil. -->
 
 ## Demographic information
 <!-- You can get a lot of the information in this section from https://analyzer.cv-toolbox.web.tr/browse -->
@@ -62,12 +65,6 @@ On average, sentences are composed by five words and contain a total of forty le
 <!-- @ OPTIONAL @ -->
 <!-- A description of the writing system (or writing systems) used in the text corpus -->
 
-#### Symbol table
-
-<!-- {{ALPHABET_TABLE}} -->
-<!-- @ OPTIONAL @ -->
-<!-- If the writing system is alphabetic, you can include the valid alphabet here -->
-
 ### Sample
 
 There follows a randomly selected sample of five sentences from the corpus:
@@ -87,37 +84,8 @@ peshun ampambanta sandoquin
 <!-- @ OPTIONAL @ -->
 <!-- A list of sentence sources, can be curated to the top-N -->
 Sentences were written by Mr. Uaqui Dunu
-### Text domains
-
-<!-- {{TEXT_DOMAIN_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- What text domains are represented in the corpus? -->
-
-### Processing
-
-<!-- {{PROCESSING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- How has the text data been processed -->
-
-### Recommended post-processing
-
-<!-- {{RECOMMENDED_POSTPROCESSING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- What should people do before they use the data, for example Unicode normalisation -->
 
 ## Get involved!
-
-### Community links
-
-<!-- {{COMMUNITY_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Links to community chats / fora -->
-
-### Discussions
-
-<!-- {{DISCUSSION_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Any links to discussions, for example on Discourse or other fora or blogs can be included here -->
 
 ### Contribute
 * [Contribute voice recordings](https://commonvoice.mozilla.org/mcf/speak)

--- a/cv-corpus/scs/23.0-2025-09-17/final/en/mki.md
+++ b/cv-corpus/scs/23.0-2025-09-17/final/en/mki.md
@@ -9,12 +9,13 @@ speech (11 hours validated) from 12 speakers.
 
 Dhatki is a regional Indo-Aryan language, mainly spoken in Sindh (Pakistan) and Rajasthan (India). It is very close to Sindhi and Rajasthani, written in different scripts depending on the region, and mostly used in daily conversation, folk songs, and local stories.
 
-### Variants
+<!-- ### Variants -->
 <!-- {{VARIANT_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Describe the variants (MCV variants) of your language -->
 
-The dataset may contain two main varieties of Dhatki:  Sindh (Pakistan) variety, Sindhi-influenced, written in Perso-Arabic script. Rajasthan (India) variety, Marwari-influenced, written in Devanagari script.
+<!-- Original Answer: -->
+<!-- The dataset may contain two main varieties of Dhatki:  Sindh (Pakistan) variety, Sindhi-influenced, written in Perso-Arabic script. Rajasthan (India) variety, Marwari-influenced, written in Devanagari script. -->
 
 ## Demographic information
 <!-- You can get a lot of the information in this section from https://analyzer.cv-toolbox.web.tr/browse -->
@@ -62,12 +63,19 @@ The corpus is written in the Sindhi script. While Dhatki can be written in eithe
 <!-- @ OPTIONAL @ -->
 <!-- If the writing system is alphabetic, you can include the valid alphabet here -->
 
-My corpus is written Sindhi, Sindhi script has 52 letters. ا ب ٻ پ ڀ ت ٿ ٽ ٺ ث ج ڄ جھ چ ڇ ح خ د ڌ ڊڍ ڏ ڍ ذر ر ڙ ز ژ س ش ص ض ط ظ ع غ ف ڦ ق ڪ گ ڳ ڱ ل ڻ ن ڃ م ء و ؤ ۏ ه ء ي ءَ ءِ ءُ
+My corpus is written Sindhi, Sindhi script has 52 letters.
+```ا ب ٻ پ ڀ ت ٿ ٽ ٺ ث ج ڄ جھ چ ڇ ح خ د ڌ ڊڍ ڏ ڍ ذر ر ڙ ز ژ س ش ص ض ط ظ ع غ ف ڦ ق ڪ گ ڳ ڱ ل ڻ ن ڃ م ء و ؤ ۏ ه ء ي ءَ ءِ ءُ```
 
 ### Sample
 <!-- {{SENTENCES_SAMPLE}} -->
 There follows a randomly selected sample of five sentences from the corpus.
-1. تايو نالو ڪي هي. 2. سيورو جلدي اٺڻ سٺي بات هي. 3. آپرو ڪم آپ ڪرڻ کپي. 4. ڪراچي سنڌ صوبي رو شهر. 5. ٿري ڌاٽڪي ٻولي ٻولي ٿا.
+```
+1. تايو نالو ڪي هي.
+2. سيورو جلدي اٺڻ سٺي بات هي.
+3. آپرو ڪم آپ ڪرڻ کپي.
+4. ڪراچي سنڌ صوبي رو شهر.
+5. ٿري ڌاٽڪي ٻولي ٻولي ٿا.
+```
 
 ### Sources
 <!-- {{SOURCES_LIST}} -->
@@ -90,28 +98,8 @@ General, Service and Retail, Healthcare, Nature and Environment, Language Fundam
 
 The corpus was created by composing original sentences in Dhatki, typing them in Sindhi script, and then editing for accuracy and consistency. Sentences were cleaned, standardized, and organized into a digital format for use in analysis.
 
-### Recommended post-processing
-<!-- {{RECOMMENDED_POSTPROCESSING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- What should people do before they use the data, for example Unicode normalisation -->
-
-no
 
 ## Get involved!
-
-
-### Community links
-<!-- {{COMMUNITY_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Links to community chats / fora -->
-
-
-
-### Discussions
-<!-- {{DISCUSSION_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Any links to discussions, for example on Discourse or other fora or blogs can be included here -->
-
 
 
 ### Contribute
@@ -127,14 +115,7 @@ no
 <!-- {{DATASHEET_AUTHORS_LIST}} -->
 <!-- A list in the format of: Your Name <email@email.com> -->
 
-
-
-### Citation guidelines
-<!-- {{CITATION_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- If you published a paper and would like people to cite it, you can include the BiBTeX here -->
-
-
+Common Voice Community
 
 ### Funding
 <!-- {{FUNDING_DESCRIPTION}} -->

--- a/cv-corpus/scs/23.0-2025-09-17/final/en/mve.md
+++ b/cv-corpus/scs/23.0-2025-09-17/final/en/mve.md
@@ -9,12 +9,13 @@ speech (11 hours validated) from 20 speakers.
 
 Marwari language is spoken all over the Pakistan also in India but mostly in Sindh. Marwari language speakers are in millions all over the world.
 
-### Variants
+<!-- ### Variants -->
 <!-- {{VARIANT_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Describe the variants (MCV variants) of your language -->
 
-Thali, Godwari, and Dhatki
+<!-- Original Answer: -->
+<!-- Thali, Godwari, and Dhatki -->
 
 ## Demographic information
 <!-- You can get a lot of the information in this section from https://analyzer.cv-toolbox.web.tr/browse -->
@@ -62,12 +63,18 @@ Self-Written
 <!-- @ OPTIONAL @ -->
 <!-- If the writing system is alphabetic, you can include the valid alphabet here -->
 
-ا ب چ د آ ف گ ه ي ج ڪ ل م ن ئ پ ق ر س ت و ش ڊ خ ٽ ز ڀ ڇ ڌ ڳ گھ ڄ جھ ک ݪ ڃ ڻ ہ ڦ ڏ ڙ ݾ ٿ ٻ ح ٺ ښ
+```ا ب چ د آ ف گ ه ي ج ڪ ل م ن ئ پ ق ر س ت و ش ڊ خ ٽ ز ڀ ڇ ڌ ڳ گھ ڄ جھ ک ݪ ڃ ڻ ہ ڦ ڏ ڙ ݾ ٿ ٻ ح ٺ ښ```
 
 ### Sample
 <!-- {{SENTENCES_SAMPLE}} -->
 There follows a randomly selected sample of five sentences from the corpus.
-وائس ٽيڪنالآجِي ريَ چوڌارِي ھيڪ برادرِي ٺاھڻ ۾ مھورِي مدد ڪرو۔  اِي ميل ريَ وسِيليَ مھون ھون رابطيَ ريا۔ آپرو اِي ميل ايڊرس لگائو۔ ٿارِي مهربونِي، آپيَ رابطي ۾ ريون۔ عام آواز ريَ ڊيٽاسَٽ طرف واپس آڻ۔ 
+```
+وائس ٽيڪنالآجِي ريَ چوڌارِي ھيڪ برادرِي ٺاھڻ ۾ مھورِي مدد ڪرو۔
+اِي ميل ريَ وسِيليَ مھون ھون رابطيَ ريا۔
+آپرو اِي ميل ايڊرس لگائو۔
+ٿارِي مهربونِي، آپيَ رابطي ۾ ريون۔
+عام آواز ريَ ڊيٽاسَٽ طرف واپس آڻ۔
+```
 
 ### Sources
 <!-- {{SOURCES_LIST}} -->
@@ -83,42 +90,14 @@ Self-Written
 
 General
 
-### Processing
-<!-- {{PROCESSING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- How has the text data been processed -->
-
-A project from Mozilla to help us for Writing. 
-
-### Recommended post-processing
-<!-- {{RECOMMENDED_POSTPROCESSING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- What should people do before they use the data, for example Unicode normalisation -->
-
-NO
 
 ## Get involved!
 
-
-### Community links
-<!-- {{COMMUNITY_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Links to community chats / fora -->
-
-NO
-
-### Discussions
-<!-- {{DISCUSSION_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Any links to discussions, for example on Discourse or other fora or blogs can be included here -->
-
-NO
 
 ### Contribute
 <!-- {{CONTRIBUTE_LINKS_LIST}} -->
 <!-- Here you can include links for how to contribute to the dataset -->
 
-NO
 
 ## Acknowledgements
 
@@ -127,21 +106,15 @@ NO
 <!-- {{DATASHEET_AUTHORS_LIST}} -->
 <!-- A list in the format of: Your Name <email@email.com> -->
 
-Self-Written 
+Common Voice Community
 
-### Citation guidelines
-<!-- {{CITATION_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- If you published a paper and would like people to cite it, you can include the BiBTeX here -->
-
-NO
 
 ### Funding
 <!-- {{FUNDING_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- If you received any funding, you can include the acknowledgement here -->
 
-Funding From Mozilla Community. Acknowledge Mr Meesum Alam. Meesum.alam12@gmail.com
+Funding From Mozilla Community. Acknowledge Mr Meesum Alam: meesum.alam12@gmail.com
 
 ## Licence
 This dataset is released under the [Creative Commons Zero (CC-0)](https://creativecommons.org/public-domain/cc0/) licence. By downloading this data

--- a/cv-corpus/scs/23.0-2025-09-17/final/en/mvy.md
+++ b/cv-corpus/scs/23.0-2025-09-17/final/en/mvy.md
@@ -7,13 +7,7 @@ speech (23 hours validated) from 56 speakers.
 <!-- {{LANGUAGE_DESCRIPTION}} -->
 <!-- Provide a brief (1-2 paragraph) description of your language -->
 
-Indus Kohistani is an Indo-Aryan language spoken in District Lower Kohistan, Upper Kohistan, Gilgit Baltistan and other parts of Pakistan. There are few books written and publsihed in this language. It is mainly a verbal language but currently young generation has started this language at social media platform and started to write in it.
-
-### Variants
-<!-- {{VARIANT_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Describe the variants (MCV variants) of your language -->
-
+Indus Kohistani is an Indo-Aryan language spoken in District Lower Kohistan, Upper Kohistan, Gilgit Baltistan and other parts of Pakistan. There are few books written and published in this language. It is mainly a verbal language but currently young generation has started this language at social media platform and started to write in it.
 
 
 ## Demographic information
@@ -55,26 +49,21 @@ Corpus contains more 6500 sentences from different open source documents or from
 <!-- @ OPTIONAL @ -->
 <!-- A description of the writing system (or writing systems) used in the text corpus -->
 
-Persio-Arabic script
+Perso-Arabic script
 
 #### Symbol table
 <!-- {{ALPHABET_TABLE}} -->
 <!-- @ OPTIONAL @ -->
 <!-- If the writing system is alphabetic, you can include the valid alphabet here -->
 
-ا ب بھ پ پھ ت تھ ٹ ٹھ ث ج جھ چ جھ ڇ ڇھ ح خ څ څھ د دھ ڈ ڈھ ذ ر رھ ڑ ز زھ ژ ژھ ڙ ڙھ س ش ݜ ص ض ط ظ ع غ ف ق ک کھ گ گھ ل لھ م مھ ن نھ ݨ و ہ ء ی ې ے
+```ا ب بھ پ پھ ت تھ ٹ ٹھ ث ج جھ چ جھ ڇ ڇھ ح خ څ څھ د دھ ڈ ڈھ ذ ر رھ ڑ ز زھ ژ ژھ ڙ ڙھ س ش ݜ ص ض ط ظ ع غ ف ق ک کھ گ گھ ل لھ م مھ ن نھ ݨ و ہ ء ی ې ے```
 
 ### Sample
 <!-- {{SENTENCES_SAMPLE}} -->
-There follows a randomly selected sample of five sentences from the corpus.
+There follows a randomly selected sample of sentences from the corpus.
+```
 بال ہمېش تمیز ہِن آں اعتراض ہمېش دلیل ہن کری کو ڇہ پرہ تاؤں نہ څابُون اَیں بئ تھی ݜُو وَل لا مُسلماں آں بنو ہاشم ݜس ظِلم نہ مُچِل ݜیں صحابی یے ہُم نبیؐ پشے لس اېک وار اوک ابو طالبہ لا قُریشؤں چَکس آؤ
-
-### Sources
-<!-- {{SOURCES_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- A list of sentence sources, can be curated to the top-N -->
-
-
+```
 
 ### Text domains
 <!-- {{TEXT_DOMAIN_DESCRIPTION}} -->
@@ -83,35 +72,8 @@ There follows a randomly selected sample of five sentences from the corpus.
 
 General, Agriculture and Food, Automotive and Transport, Healthcare, History, Law and Governmant, Media and Entertainment, Nature and Environment, News and Current Affairs, Technology and Robotics, Language Fundamentals (e.g. Digits, Letters, Money)
 
-### Processing
-<!-- {{PROCESSING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- How has the text data been processed -->
-
-
-
-### Recommended post-processing
-<!-- {{RECOMMENDED_POSTPROCESSING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- What should people do before they use the data, for example Unicode normalisation -->
-
-
 
 ## Get involved!
-
-
-### Community links
-<!-- {{COMMUNITY_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Links to community chats / fora -->
-
-
-
-### Discussions
-<!-- {{DISCUSSION_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Any links to discussions, for example on Discourse or other fora or blogs can be included here -->
-
 
 
 ### Contribute
@@ -127,20 +89,7 @@ General, Agriculture and Food, Automotive and Transport, Healthcare, History, La
 <!-- {{DATASHEET_AUTHORS_LIST}} -->
 <!-- A list in the format of: Your Name <email@email.com> -->
 
-
-
-### Citation guidelines
-<!-- {{CITATION_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- If you published a paper and would like people to cite it, you can include the BiBTeX here -->
-
-
-
-### Funding
-<!-- {{FUNDING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- If you received any funding, you can include the acknowledgement here -->
-
+Common Voice Community
 
 
 ## Licence

--- a/cv-corpus/scs/23.0-2025-09-17/final/en/nhi.md
+++ b/cv-corpus/scs/23.0-2025-09-17/final/en/nhi.md
@@ -19,12 +19,14 @@ The sentences in this corpus come from the `nhi` Universal Dependencies treebank
 from all three municipalities, and a set of dictionary-style example sentences written by a speaker from the 
 Tepetzintla municipality.
 
-### Variants 
+<!-- ### Variants -->
 
 <!-- {{VARIANT_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Describe the variants (MCV variants) of your language -->
-There are currently no variants defined for Western Sierra Puebla Nahuatl.
+
+<!-- Original Answer: -->
+<!-- There are currently no variants defined for Western Sierra Puebla Nahuatl. -->
 
 ## Demographic information
 <!-- You can get a lot of the information in this section from https://analyzer.cv-toolbox.web.tr/browse -->
@@ -90,7 +92,7 @@ In most cases, Spanish loans, even those with Nahuatl morphology, are written in
 <!-- @ OPTIONAL @ -->
 <!-- If the writing system is alphabetic, you can include the valid alphabet here -->
 
-`a b c ch cu d e f g h i j k l m n ñ o p qu r s t tl tz u v w x y`
+```a b c ch cu d e f g h i j k l m n ñ o p qu r s t tl tz u v w x y```
 
 Note that of the alphabet listed above, `b d f g j k ñ r v w` are used for loanwords and some proper names only.
 
@@ -113,7 +115,7 @@ Cualtzin uelic atzintlin
 <!-- @ OPTIONAL @ -->
 <!-- A list of sentence sources, can be curated to the top-N -->
 
-* [subset of UD corpus](https://github.com/UniversalDependencies/UD_Western_Sierra_Puebla_Nahuatl-ITML) (Public domain)
+* [Subset of UD corpus](https://github.com/UniversalDependencies/UD_Western_Sierra_Puebla_Nahuatl-ITML) (Public domain)
 * Individual sentences submitted by users through the Mozilla Common Voice interface (Public domain)
 
 ### Text domains
@@ -132,26 +134,8 @@ Cualtzin uelic atzintlin
 The original sentences from the UD treebank are written in varying orthographic norms. Prior to their inclusion into the Common Voice corpus,
 the orthgoraphy was converted to the SIL San Miguel Tenango orthography ("ilv") using a rule-based automatic converter from the [py-elotl Python package](https://aclanthology.org/2025.americasnlp-1.5/), followed by some manual verification.
 
-### Recommended post-processing
-
-<!-- {{RECOMMENDED_POSTPROCESSING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- What should people do before they use the data, for example Unicode normalisation -->
-None
 
 ## Get involved!
-
-### Community links
-
-<!-- {{COMMUNITY_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Links to community chats / fora -->
-
-### Discussions
-
-<!-- {{DISCUSSION_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Any links to discussions, for example on Discourse or other fora or blogs can be included here -->
 
 ### Contribute
 
@@ -170,18 +154,6 @@ None
 <!-- {{DATASHEET_AUTHORS_LIST}} -->
 <!-- A list in the format of: Your Name <email@email.com> -->
 * Robert A. Pugh <robertp@mozillafoundation.org>
-
-### Citation guidelines
-
-<!-- {{CITATION_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- If you published a paper and would like people to cite it, you can include the BiBTeX here -->
-
-### Funding
-
-<!-- {{FUNDING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- If you received any funding, you can include the acknowledgement here -->
 
 ## Licence
 

--- a/cv-corpus/scs/23.0-2025-09-17/final/en/nn-NO.md
+++ b/cv-corpus/scs/23.0-2025-09-17/final/en/nn-NO.md
@@ -14,9 +14,10 @@ The language code is `nn` and the locale is `nn-NO` (Nynorsk as written in Norwa
 locale includes the region code for historical reasons relating to the localisation platform. The dataset
 contains Norwegian as spoken anywhere and as written in the Nynorsk standard.
 
-### Variants 
+<!-- ### Variants -->
 
-There are currently no variants defined for Norwegian Nynorsk.
+<!-- Original Answer: -->
+<!-- There are currently no variants defined for Norwegian Nynorsk. -->
 
 ## Demographic information
 
@@ -26,24 +27,9 @@ The dataset includes the following distribution of age and gender.
 
 Self-declared gender information, frequency refers to the number of clips annotated with this gender.
 
-| Gender | Frequency |
-|--------|-----------|
-| male, masculine | 686 |
-| undeclared | 331 |
-| female, feminine | 165 |
-
 ### Age
 
 Self-declared age information, frequency refers to the number of clips annotated with this age band.
-
-| Age band | Frequency |
-|----------|-----------|
-| thirties | 513 |
-| twenties | 308 |
-| undeclared | 301 |
-| fourties | 34 |
-| teens | 24 |
-| fifties | 2 |
 
 ## Text corpus
 
@@ -136,7 +122,6 @@ Nynorsk-only words:
 These candidate sentences were then checked by two writers of Nynorsk to ensure that they were indeed written
 in Nynorsk before inclusion into the corpus.
 
-### Recommended post-processing
 
 ## Get involved!
 

--- a/cv-corpus/scs/23.0-2025-09-17/final/en/phl.md
+++ b/cv-corpus/scs/23.0-2025-09-17/final/en/phl.md
@@ -9,12 +9,13 @@ speech (22 hours validated) from 20 speakers.
 
 Palula is an Indo-Aryan language, specifically a branch of the Dardic group, closely related to Shina. Palula is spoken in several regions of Chitral District, including Ashret, Biori, Kalkatak, and parts of Shishi Koh. Beyond Chitral, it is also spoken in Gumandan (Dir Kohistan) and Sao village in Kunar Province, Afghanistan. The estimated number of speakers ranges between 20,000 and 25,000.
 
-### Variants
+<!-- ### Variants -->
 <!-- {{VARIANT_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Describe the variants (MCV variants) of your language -->
 
-The dataset comprises a diverse range of linguistic and cultural materials collected from Palula-speaking communities, reflecting the richness of their oral and written traditions. These varieties include: Folk tales, traditional narratives passed down through generations. Cultural and experience stories narratives that document lived experience, seasonal practices, and social customs. Proverbs and Idiomatic Expressions in Palula with Urdu translation. Poetic Texts, Original and traditional poetry composed in Palula with Urdu translation. 
+<!-- Original Answer: -->
+<!-- The dataset comprises a diverse range of linguistic and cultural materials collected from Palula-speaking communities, reflecting the richness of their oral and written traditions. These varieties include: Folk tales, traditional narratives passed down through generations. Cultural and experience stories narratives that document lived experience, seasonal practices, and social customs. Proverbs and Idiomatic Expressions in Palula with Urdu translation. Poetic Texts, Original and traditional poetry composed in Palula with Urdu translation. -->
 
 ## Demographic information
 <!-- You can get a lot of the information in this section from https://analyzer.cv-toolbox.web.tr/browse -->
@@ -62,19 +63,29 @@ Palula orthography based on the Arabic writing system
 <!-- @ OPTIONAL @ -->
 <!-- If the writing system is alphabetic, you can include the valid alphabet here -->
 
-ا ، ب ، پ ، ت ، ث، ٹ، ج، چ ،ڇ ،څ، ح ، خ، د ، ڈ ،ذ ، ر، ز، ژ، ڙ، س، ش، ݜ، ص، ض، ط، ظ، ع، غ، ف، ق، ک، گ، ل، م، ن، ں، ݨ، و، ہ،ھ،ء،ی،ے 
+```ا ب پ ت ث ٹ ج چ ڇ څ ح خ د ڈ ذ ر ز ژ ڙ س ش ݜ ص ض ط ظ ع غ ف ق ک گ ل م ن ں ݨ و ہ ھ ء ی ے ```
 
 ### Sample
 <!-- {{SENTENCES_SAMPLE}} -->
 There follows a randomly selected sample of five sentences from the corpus.
-انی گھوݜٹہ کتی کمرے ہنہ؟ اندہ دُو کمرے آک بہ پراجمی دیرہ ہنوۡ۔ تھی انیۡ کُڈ خختمی دِتیۡ ہِنم کی بٹومی؟ انیوے بُٹھے خختم استعمال بھِلم ہِنم، بٹومی کڈ دتی ہِنیۡ۔  تھی گھوݜٹہ کتی جانہ ہِنہ؟  
+```
+انی گھوݜٹہ کتی کمرے ہنہ؟
+اندہ دُو کمرے آک بہ پراجمی دیرہ ہنوۡ۔
+تھی انیۡ کُڈ خختمی دِتیۡ ہِنم کی بٹومی؟
+انیوے بُٹھے خختم استعمال بھِلم ہِنم، بٹومی کڈ دتی ہِنیۡ۔
+تھی گھوݜٹہ کتی جانہ ہِنہ؟
+```
 
 ### Sources
 <!-- {{SOURCES_LIST}} -->
 <!-- @ OPTIONAL @ -->
 <!-- A list of sentence sources, can be curated to the top-N -->
 
-- Palula Matli (Proverbs) – Author: Naseem Haider - Palula Textbook – Author:  Naseem Haider - Palula Gul-Dasta Ashaar (Poetry) – Author: Naseem Haider - Palula–Urdu–English Conversation Guide – Author: Naseem Haider - Palula Folk Tales – Author: Naseem Haider 
+* Palula Matli (Proverbs) – Author: Naseem Haider
+* Palula Textbook – Author:  Naseem Haider
+* Palula Gul-Dasta Ashaar (Poetry) – Author: Naseem Haider 
+* Palula–Urdu–English Conversation Guide – Author: Naseem Haider 
+* Palula Folk Tales – Author: Naseem Haider 
 
 ### Text domains
 <!-- {{TEXT_DOMAIN_DESCRIPTION}} -->
@@ -90,13 +101,6 @@ General, Agriculture and Food, Healthcare, History, Law and Governmant, Media an
 
 The process involved collecting texts, stories, and proverbs through community-based audio recordings. These recordings were transcribed, and selected sentences were curated for inclusion in the Common Voice dataset. The finalized dataset was then uploaded and subsequently recorded by multiple speakers. 
 
-### Recommended post-processing
-<!-- {{RECOMMENDED_POSTPROCESSING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- What should people do before they use the data, for example Unicode normalisation -->
-
-The datasets should be reachable to everyone for adding the sentences and uploading their recording. 
-
 ## Get involved!
 
 
@@ -105,20 +109,12 @@ The datasets should be reachable to everyone for adding the sentences and upload
 <!-- @ OPTIONAL @ -->
 <!-- Links to community chats / fora -->
 
-https://www.palulacommunity.org  
-
-### Discussions
-<!-- {{DISCUSSION_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Any links to discussions, for example on Discourse or other fora or blogs can be included here -->
-
-https://www.palulacommunity.org  
+* [Palula Community Welfare Organization website](https://www.palulacommunity.org)
 
 ### Contribute
 <!-- {{CONTRIBUTE_LINKS_LIST}} -->
 <!-- Here you can include links for how to contribute to the dataset -->
 
-https://www.palulacommunity.org  
 
 ## Acknowledgements
 
@@ -127,13 +123,7 @@ https://www.palulacommunity.org
 <!-- {{DATASHEET_AUTHORS_LIST}} -->
 <!-- A list in the format of: Your Name <email@email.com> -->
 
-Naseem Haider naseemhaider78@gmail.com   
-
-### Citation guidelines
-<!-- {{CITATION_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- If you published a paper and would like people to cite it, you can include the BiBTeX here -->
-
+* Naseem Haider <naseemhaider78@gmail.com>
 
 
 ### Funding
@@ -141,7 +131,7 @@ Naseem Haider naseemhaider78@gmail.com
 <!-- @ OPTIONAL @ -->
 <!-- If you received any funding, you can include the acknowledgement here -->
 
-Meesum Alam Meesum.alam12@gmail.com  
+Meesum Alam: meesum.alam12@gmail.com  
 
 ## Licence
 This dataset is released under the [Creative Commons Zero (CC-0)](https://creativecommons.org/public-domain/cc0/) licence. By downloading this data

--- a/cv-corpus/scs/23.0-2025-09-17/final/en/phr.md
+++ b/cv-corpus/scs/23.0-2025-09-17/final/en/phr.md
@@ -9,12 +9,13 @@ speech (15 hours validated) from 63 speakers.
 
 Pahari-Pothwari is a group of dialects spoken in the Pothohar Plateau of Punjab, Pakistan, and across the border in Azad Jammu and Kashmir (AJK). The name is a combination of two closely related dialect clusters: Pahari (literally "of the hills") and Pothwari (referring to the Pothohar region). Pahari-Pothwari belongs to the Indo-Aryan family of languages. It shares lexical and grammatical similarity with these languages.
 
-### Variants
+<!-- ### Variants -->
 <!-- {{VARIANT_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Describe the variants (MCV variants) of your language -->
 
-The dataset comprises sentences that characterize the Pahari-speaking population residing in the Poonch district of Azad Jammu and Kashmir.
+<!-- Original Answer: -->
+<!-- The dataset comprises sentences that characterize the Pahari-speaking population residing in the Poonch district of Azad Jammu and Kashmir. -->
 
 ## Demographic information
 <!-- You can get a lot of the information in this section from https://analyzer.cv-toolbox.web.tr/browse -->
@@ -57,24 +58,23 @@ The dataset comprises a speech corpus totaling 15 hours, containing 2,077 Pahari
 
 The writing system used for the corpus is based on the Urdu orthography. The corpus was written using the same Urdu script and follows the right-to-left direction of Urdu.
 
-#### Symbol table
-<!-- {{ALPHABET_TABLE}} -->
-<!-- @ OPTIONAL @ -->
-<!-- If the writing system is alphabetic, you can include the valid alphabet here -->
-
 The Urdu alphabet was utilized for transcription.
+
 
 ### Sample
 <!-- {{SENTENCES_SAMPLE}} -->
-There follows a randomly selected sample of five sentences from the corpus.
+There follows a randomly selected sample of sentences from the corpus.
+```
 پتہ نئیں کوئِیاں اس نی سوچ بسرے ویلے گئی اُٹھی ایہھے کرنیاں بانیاں او اپنے نکوٹے نے ویلے نیاں گلاں بانے لاغے اُنی اج  پھیدری پھیدری شازیہ باقیں کولا ٹھوالی انیں وچ جوان کڑیاں جنگت نالے اس نے ہم قوم زیادے سے کہھڑی چھٹ ہور لنگتھی
+```
 
 ### Sources
 <!-- {{SOURCES_LIST}} -->
 <!-- @ OPTIONAL @ -->
 <!-- A list of sentence sources, can be curated to the top-N -->
 
-Published books of Dr. Muhammad Saghir Khan Daily conversation of Pahari speakers
+Published books of Dr. Muhammad Saghir Khan.
+Daily conversation of Pahari speakers.
 
 ### Text domains
 <!-- {{TEXT_DOMAIN_DESCRIPTION}} -->
@@ -90,34 +90,12 @@ General
 
 The text was written in Unicode, following the conventions of Urdu orthography.
 
-### Recommended post-processing
-<!-- {{RECOMMENDED_POSTPROCESSING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- What should people do before they use the data, for example Unicode normalisation -->
-
-
-
 ## Get involved!
-
-
-### Community links
-<!-- {{COMMUNITY_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Links to community chats / fora -->
-
-
-
-### Discussions
-<!-- {{DISCUSSION_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Any links to discussions, for example on Discourse or other fora or blogs can be included here -->
-
 
 
 ### Contribute
 <!-- {{CONTRIBUTE_LINKS_LIST}} -->
 <!-- Here you can include links for how to contribute to the dataset -->
-
 
 
 ## Acknowledgements
@@ -127,14 +105,7 @@ The text was written in Unicode, following the conventions of Urdu orthography.
 <!-- {{DATASHEET_AUTHORS_LIST}} -->
 <!-- A list in the format of: Your Name <email@email.com> -->
 
-Dr. Muhammad Saghir Khan <saghirrawlakot@gmail.com>
-
-### Citation guidelines
-<!-- {{CITATION_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- If you published a paper and would like people to cite it, you can include the BiBTeX here -->
-
-
+* Dr. Muhammad Saghir Khan <saghirrawlakot@gmail.com>
 
 ### Funding
 <!-- {{FUNDING_DESCRIPTION}} -->

--- a/cv-corpus/scs/23.0-2025-09-17/final/en/sbn.md
+++ b/cv-corpus/scs/23.0-2025-09-17/final/en/sbn.md
@@ -7,14 +7,15 @@ speech (11 hours validated) from 21 speakers.
 <!-- {{LANGUAGE_DESCRIPTION}} -->
 <!-- Provide a brief (1-2 paragraph) description of your language -->
 
-Umerkot, Noukot, Kunri and Badin. speakers are in thousands.
+Umerkot, Noukot, Kunri and Badin. Speakers are in thousands.
 
-### Variants
+<!-- ### Variants -->
 <!-- {{VARIANT_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Describe the variants (MCV variants) of your language -->
 
-sindhi and Dhatki
+<!-- Original Answer: -->
+<!-- sindhi and Dhatki -->
 
 ## Demographic information
 <!-- You can get a lot of the information in this section from https://analyzer.cv-toolbox.web.tr/browse -->
@@ -62,12 +63,15 @@ Self-Written
 <!-- @ OPTIONAL @ -->
 <!-- If the writing system is alphabetic, you can include the valid alphabet here -->
 
-ا آ ب ٻ ڀ ت ٿ ٽ ٺ پ ج ڄ جھ ڃ چ ڇ د ڌ ڏ ڊ ڍ ر ڙ ز س ش ڦ ڪ ک گ ڳ گھ ڱ ل م ن ݩ ڻ ۈ و ۆ ه ء ىٰ ي ێ َ ِ ُ   
+```ا آ ب ٻ ڀ ت ٿ ٽ ٺ پ ج ڄ جھ ڃ چ ڇ د ڌ ڏ ڊ ڍ ر ڙ ز س ش ڦ ڪ ک گ ڳ گھ ڱ ل م ن ݩ ڻ ۈ و ۆ ه ء ىٰ ي ێ َ ِ ُ   ```
 
 ### Sample
 <!-- {{SENTENCES_SAMPLE}} -->
-There follows a randomly selected sample of five sentences from the corpus.
-تر رآ سڀ مآڻهوٚ  اُٺ ري وآرآنٚ مآنٚ ٺهيل ڪپڙآ پهرتو ائيٚنٚ جھنٚگليٚ مآکيٚ کآئيٚتو۔ هڪڙو ايڙو مآڻهوٚ آڻ وآرو اهي موٚنٚ کآݩ وڌيٚڪ ڪزرت وآرو اهي
+There follows a randomly selected sample of sentences from the corpus.
+```
+تر رآ سڀ مآڻهوٚ  اُٺ ري وآرآنٚ مآنٚ ٺهيل ڪپڙآ پهرتو ائيٚنٚ جھنٚگليٚ مآکيٚ کآئيٚتو۔
+هڪڙو ايڙو مآڻهوٚ آڻ وآرو اهي موٚنٚ کآݩ وڌيٚڪ ڪزرت وآرو اهي
+```
 
 ### Sources
 <!-- {{SOURCES_LIST}} -->
@@ -83,42 +87,14 @@ Self-Written
 
 General
 
-### Processing
-<!-- {{PROCESSING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- How has the text data been processed -->
-
-No
-
-### Recommended post-processing
-<!-- {{RECOMMENDED_POSTPROCESSING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- What should people do before they use the data, for example Unicode normalisation -->
-
-No
 
 ## Get involved!
 
-
-### Community links
-<!-- {{COMMUNITY_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Links to community chats / fora -->
-
-No
-
-### Discussions
-<!-- {{DISCUSSION_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Any links to discussions, for example on Discourse or other fora or blogs can be included here -->
-
-No
 
 ### Contribute
 <!-- {{CONTRIBUTE_LINKS_LIST}} -->
 <!-- Here you can include links for how to contribute to the dataset -->
 
-No
 
 ## Acknowledgements
 
@@ -127,21 +103,15 @@ No
 <!-- {{DATASHEET_AUTHORS_LIST}} -->
 <!-- A list in the format of: Your Name <email@email.com> -->
 
-Self-Written 
+Common Voice Community
 
-### Citation guidelines
-<!-- {{CITATION_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- If you published a paper and would like people to cite it, you can include the BiBTeX here -->
-
-No
 
 ### Funding
 <!-- {{FUNDING_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- If you received any funding, you can include the acknowledgement here -->
 
-From Mozilla Community. acknowledge Meesum Alam Meesum.alam12@gmail.com 
+From Mozilla Community. Acknowledge Meesum Alam: meesum.alam12@gmail.com 
 
 ## Licence
 This dataset is released under the [Creative Commons Zero (CC-0)](https://creativecommons.org/public-domain/cc0/) licence. By downloading this data

--- a/cv-corpus/scs/23.0-2025-09-17/final/en/scl.md
+++ b/cv-corpus/scs/23.0-2025-09-17/final/en/scl.md
@@ -9,12 +9,13 @@ speech (11 hours validated) from 39 speakers.
 
 Shina language is one of the major languages of Gilgit Baltistan Pakistan. It's spoken in Gilgit, Astore, Chilas, Kohistan and some areas in Sakrdu Baltistan. It is also spoken in some areas of India. Gilgiti and Astori dialects are considered to be its major dialects. The dialect spoken in Gilgit is known as the main and standard dialect.
 
-### Variants
+<!-- ### Variants -->
 <!-- {{VARIANT_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Describe the variants (MCV variants) of your language -->
 
-1. Gilgiti 2. Astori (locally known as Astorija) 3. Chilasi 4. Kohistani shina 5. Gurezi 
+<!-- Original Answer: -->
+<!-- 1. Gilgiti 2. Astori (locally known as Astorija) 3. Chilasi 4. Kohistani shina 5. Gurezi --> 
 
 ## Demographic information
 <!-- You can get a lot of the information in this section from https://analyzer.cv-toolbox.web.tr/browse -->
@@ -55,62 +56,35 @@ It mostly comes from textbooks, and social media platforms. There are one thousa
 <!-- @ OPTIONAL @ -->
 <!-- A description of the writing system (or writing systems) used in the text corpus -->
 
-The Shina language in Gilgit-Baltistan, Pakistan, is written in a variation of the Arabic script. This script is reported to be adapted to represent the unique sounds of the Shina language, with additional letters such as: - ݜ for /ʂ/ - ڙ for /ʐ/ - څ for /ts/ - ڇ for /ʈʂ/ - ݨ for /ɳ/
+The Shina language in Gilgit-Baltistan, Pakistan, is written in a variation of the Arabic script. This script is reported to be adapted to represent the unique sounds of the Shina language, with additional letters such as: 
+- ݜ for /ʂ/ 
+- ڙ for /ʐ/ 
+- څ for /ts/ 
+- ڇ for /ʈʂ/ 
+- ݨ for /ɳ/ 
 
 #### Symbol table
 <!-- {{ALPHABET_TABLE}} -->
 <!-- @ OPTIONAL @ -->
 <!-- If the writing system is alphabetic, you can include the valid alphabet here -->
 
- ا ب پ ت ٹ ث ج چ ح خ څ ڇ د ڈ ذ ر ڑ ز ژ ڙ س ش ݜ ص ض ط ظ ع غ ڠ ف ق ک گ ل م ن ݨ ں و ہ ھ ء ی ے  
+``` ا ب پ ت ٹ ث ج چ ح خ څ ڇ د ڈ ذ ر ڑ ز ژ ڙ س ش ݜ ص ض ط ظ ع غ ڠ ف ق ک گ ل م ن ݨ ں و ہ ھ ء ی ے```  
 
 ### Sample
 <!-- {{SENTENCES_SAMPLE}} -->
 There follows a randomly selected sample of five sentences from the corpus.
-1۔ ووئی پییَموس۔ 2. چہ ڇووں ہوں۔ 3. راتی ڙینگی ہِیں۔ 4. اوشی آلی۔ 5. والو کھیݨ پھݜ بِیلو۔
-
-### Sources
-<!-- {{SOURCES_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- A list of sentence sources, can be curated to the top-N -->
-
-
-
-### Text domains
-<!-- {{TEXT_DOMAIN_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- What text domains are represented in the corpus? -->
-
-
-
-### Processing
-<!-- {{PROCESSING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- How has the text data been processed -->
-
-
-
-### Recommended post-processing
-<!-- {{RECOMMENDED_POSTPROCESSING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- What should people do before they use the data, for example Unicode normalisation -->
+```
+1۔ ووئی پییَموس۔
+2. چہ ڇووں ہوں۔
+3. راتی ڙینگی ہِیں۔
+4. اوشی آلی۔
+5. والو کھیݨ پھݜ بِیلو۔
+```
 
 
 
 ## Get involved!
 
-
-### Community links
-<!-- {{COMMUNITY_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Links to community chats / fora -->
-
-
-
-### Discussions
-<!-- {{DISCUSSION_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Any links to discussions, for example on Discourse or other fora or blogs can be included here -->
 
 
 
@@ -127,20 +101,7 @@ There follows a randomly selected sample of five sentences from the corpus.
 <!-- {{DATASHEET_AUTHORS_LIST}} -->
 <!-- A list in the format of: Your Name <email@email.com> -->
 
-
-
-### Citation guidelines
-<!-- {{CITATION_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- If you published a paper and would like people to cite it, you can include the BiBTeX here -->
-
-
-
-### Funding
-<!-- {{FUNDING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- If you received any funding, you can include the acknowledgement here -->
-
+Common Voice Community
 
 
 ## Licence

--- a/cv-corpus/scs/23.0-2025-09-17/final/en/sd.md
+++ b/cv-corpus/scs/23.0-2025-09-17/final/en/sd.md
@@ -9,12 +9,13 @@ speech (0.4 hours validated) from 25 speakers.
 
 Sindhi (سنڌي) is an Indo-Aryan language spoken mainly in Sindh, Pakistan, and also in India. It has millions of speakers, a rich literary history, and is written in both Perso-Arabic and Devanagari scripts.
 
-### Variants
+<!-- ### Variants -->
 <!-- {{VARIANT_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Describe the variants (MCV variants) of your language -->
 
-Sindhi has several dialects, including Siroli (spoken in upper Sindh), Lari (spoken in lower Sindh), Thari (spoken in Tharparkar), and Kutchi (spoken in Kutch, India). The standard variety is based on the central Sindh dialect.
+<!-- Original Answer: -->
+<!-- Sindhi has several dialects, including Siroli (spoken in upper Sindh), Lari (spoken in lower Sindh), Thari (spoken in Tharparkar), and Kutchi (spoken in Kutch, India). The standard variety is based on the central Sindh dialect. -->
 
 ## Demographic information
 <!-- You can get a lot of the information in this section from https://analyzer.cv-toolbox.web.tr/browse -->
@@ -62,19 +63,16 @@ The Sindhi corpus is written in the Perso-Arabic script, which is the standard s
 <!-- @ OPTIONAL @ -->
 <!-- If the writing system is alphabetic, you can include the valid alphabet here -->
 
-The Sindhi Perso-Arabic script (used in newspapers) has 52 letters. Here is the full alphabet list separated by spaces:  ا ب ٻ ڀ پ ت ٿ ٽ ٺ ث ج جه ڄ چ ڇ ح خ د ڌ ڏ ڊ ڍ ذ ر ڙ ڍ ز س ش ص ض ط ظ ع غ ف ڦ ق ڪ گ ڳ گه ڱ ل ڻ ن ڃ م و ء ه ة ي ئ
+The Sindhi Perso-Arabic script (used in newspapers) has 52 letters. Here is the full alphabet list separated by spaces:
+```ا ب ٻ ڀ پ ت ٿ ٽ ٺ ث ج جه ڄ چ ڇ ح خ د ڌ ڏ ڊ ڍ ذ ر ڙ ڍ ز س ش ص ض ط ظ ع غ ف ڦ ق ڪ گ ڳ گه ڱ ل ڻ ن ڃ م و ء ه ة ي ئ```
 
 ### Sample
 <!-- {{SENTENCES_SAMPLE}} -->
-There follows a randomly selected sample of five sentences from the corpus.
+There follows a randomly selected sample of sentences from the corpus.
+
+```
 ڳوٺ محمد ابراهيم سومرو ۾ پورهيت چاڪر سومرو جي گهر کي باهه لڳي وئي عوامي تحريڪ ضلعي صدر ايڊووڪيٽ نياز بھراڻي  قتل ٿيل امجد علي لاشاري جي والد عرس لاشاري احتجاج ڪيو ايس ايس پي سنگهار ملڪ جي وڪيل جي پونيئرن سان تعزيت قوم سميت واٽر ڪارپوريشن جي سمورن آفيسرن ۽ ملازمن کي مبارڪون
-
-### Sources
-<!-- {{SOURCES_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- A list of sentence sources, can be curated to the top-N -->
-
-
+```
 
 ### Text domains
 <!-- {{TEXT_DOMAIN_DESCRIPTION}} -->
@@ -99,21 +97,6 @@ It is recommended to clean the text for duplicate articles, normalize spellings,
 
 ## Get involved!
 
-
-### Community links
-<!-- {{COMMUNITY_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Links to community chats / fora -->
-
-Currently, there are no dedicated community links. Users can connect through Mozilla’s open-source language community channels 
-
-### Discussions
-<!-- {{DISCUSSION_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Any links to discussions, for example on Discourse or other fora or blogs can be included here -->
-
-
-
 ### Contribute
 <!-- {{CONTRIBUTE_LINKS_LIST}} -->
 <!-- Here you can include links for how to contribute to the dataset -->
@@ -127,21 +110,15 @@ Currently, there are no dedicated community links. Users can connect through Moz
 <!-- {{DATASHEET_AUTHORS_LIST}} -->
 <!-- A list in the format of: Your Name <email@email.com> -->
 
+Common Voice Community
 
-
-### Citation guidelines
-<!-- {{CITATION_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- If you published a paper and would like people to cite it, you can include the BiBTeX here -->
-
-  
 
 ### Funding
 <!-- {{FUNDING_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- If you received any funding, you can include the acknowledgement here -->
 
-This dataset was created with funding support from Mozilla. Special acknowledgments to Meesam Alam (Meesum.alam12@gmail.com) for contributions and support.
+This dataset was created with funding support from Mozilla. Special acknowledgments to Meesam Alam (meesum.alam12@gmail.com) for contributions and support.
 
 ## Licence
 This dataset is released under the [Creative Commons Zero (CC-0)](https://creativecommons.org/public-domain/cc0/) licence. By downloading this data

--- a/cv-corpus/scs/23.0-2025-09-17/final/en/ssi.md
+++ b/cv-corpus/scs/23.0-2025-09-17/final/en/ssi.md
@@ -7,14 +7,15 @@ speech (11 hours validated) from 21 speakers.
 <!-- {{LANGUAGE_DESCRIPTION}} -->
 <!-- Provide a brief (1-2 paragraph) description of your language -->
 
-Three Hundred Thousand Plus 
+The Sansi language is spoken by the Sansi people on the Indian subcontinent. The language is considered highly endangered.
 
-### Variants
+<!-- ### Variants -->
 <!-- {{VARIANT_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Describe the variants (MCV variants) of your language -->
 
-مارواڑی،سنسکرت،ہندی،سندھی،اردو
+<!-- Original Answer: -->
+<!-- مارواڑی،سنسکرت،ہندی،سندھی،اردو -->
 
 ## Demographic information
 <!-- You can get a lot of the information in this section from https://analyzer.cv-toolbox.web.tr/browse -->
@@ -48,7 +49,8 @@ Self-declared age information, frequency refers to the number of clips annotated
 <!-- @ OPTIONAL @ -->
 <!-- An overview of the text corpus, with information such as average length (in characters and words) of validated sentences. -->
 
-دو هزار جملے سانسی سماج کے کُچھ حقیقی کہانی اور باقی گھریلو زبان میں جملے ہے
+<!-- دو هزار جملے سانسی سماج کے کُچھ حقیقی کہانی اور باقی گھریلو زبان میں جملے ہے -->
+
 
 ### Writing system
 <!-- {{WRITING_SYSTEM_DESCRIPTION}} -->
@@ -62,12 +64,14 @@ Perso Arabic
 <!-- @ OPTIONAL @ -->
 <!-- If the writing system is alphabetic, you can include the valid alphabet here -->
 
-ا آ ب ٻ پ ت ٹ  ج چ ح خ د دٓ ڈ ڈٓ  ر ڑ ز  س ش  ف  ک گ ل لٓ م ن ں ڻ و ہ ھ ی ئ ے 
+```ا آ ب ٻ پ ت ٹ  ج چ ح خ د دٓ ڈ ڈٓ  ر ڑ ز  س ش  ف  ک گ ل لٓ م ن ں ڻ و ہ ھ ی ئ ے ```
 
 ### Sample
 <!-- {{SENTENCES_SAMPLE}} -->
 There follows a randomly selected sample of five sentences from the corpus.
+```
 چھوری تالٓا میلٓ تو ماؤں کُو کیہ دٓیگڑی دھووَ ٻائی ڈٓرے متی چھورا پاڻْی لاؤ ہوں تیسے دھو مراؤں گڑا 
+```
 
 ### Sources
 <!-- {{SOURCES_LIST}} -->
@@ -83,36 +87,9 @@ Kishor Kumar sansi
 
 General
 
-### Processing
-<!-- {{PROCESSING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- How has the text data been processed -->
-
- Software 
-
-### Recommended post-processing
-<!-- {{RECOMMENDED_POSTPROCESSING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- What should people do before they use the data, for example Unicode normalisation -->
-
-No
 
 ## Get involved!
 
-
-### Community links
-<!-- {{COMMUNITY_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Links to community chats / fora -->
-
-No
-
-### Discussions
-<!-- {{DISCUSSION_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Any links to discussions, for example on Discourse or other fora or blogs can be included here -->
-
-No
 
 ### Contribute
 <!-- {{CONTRIBUTE_LINKS_LIST}} -->
@@ -127,21 +104,14 @@ No
 <!-- {{DATASHEET_AUTHORS_LIST}} -->
 <!-- A list in the format of: Your Name <email@email.com> -->
 
-No
-
-### Citation guidelines
-<!-- {{CITATION_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- If you published a paper and would like people to cite it, you can include the BiBTeX here -->
-
-No
+Common Voice Community
 
 ### Funding
 <!-- {{FUNDING_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- If you received any funding, you can include the acknowledgement here -->
 
-Last funding received from Mozilla Community. Mr Meesum Alam Meesum.alam@gmail.com
+Last funding received from Mozilla Community. Mr Meesum Alam: meesum.alam@gmail.com
 
 ## Licence
 This dataset is released under the [Creative Commons Zero (CC-0)](https://creativecommons.org/public-domain/cc0/) licence. By downloading this data

--- a/cv-corpus/scs/23.0-2025-09-17/final/en/trw.md
+++ b/cv-corpus/scs/23.0-2025-09-17/final/en/trw.md
@@ -7,14 +7,15 @@ speech (19 hours validated) from 27 speakers.
 <!-- {{LANGUAGE_DESCRIPTION}} -->
 <!-- Provide a brief (1-2 paragraph) description of your language -->
 
-Torwali is an Indo-Aryan language belongs to its sub-group Dardic and is spoken by about 150k people in the upper mountainous reaches of the Swat valley in Pakistan
+Torwali is an Indo-Aryan language belongs to its sub-group Dardic and is spoken by about 150k people in the upper mountainous reaches of the Swat valley in Pakistan.
 
-### Variants
+<!-- ### Variants -->
 <!-- {{VARIANT_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Describe the variants (MCV variants) of your language -->
 
-Sinkaen, Chail
+<!-- Original Answer: -->
+<!-- Sinkaen, Chail -->
 
 ## Demographic information
 <!-- You can get a lot of the information in this section from https://analyzer.cv-toolbox.web.tr/browse -->
@@ -61,20 +62,50 @@ The writing system is based on the Perso-Arabic script
 <!-- {{ALPHABET_TABLE}} -->
 <!-- @ OPTIONAL @ -->
 <!-- If the writing system is alphabetic, you can include the valid alphabet here -->
-
-أ، ا، اَ، آ، اِ، اُ، اُو، او، ای، اے، ب، پ۔ ت، ٹ، ث، ج، چ، ڇ، ح، خ، د، ڈ، ذ، ر، ڑ، ژ، ز، ڙ، س، ش، ݜ، ص، ض، ط، ظ، ع، غ، ک۔، گ، ف، ق، ل، م، ن، ں، ہ، ء، ے، ی؛ بھ، پھ، تھ، ٹھ، جھ، چھ، ڇھ، دھ، ڈھ، ڑھ، ڙھ، کھ، گھ، لھ، مھ، نھ
+```أ ا اَ آ اِ اُ اُو او ای اے ب پ ت ٹ ث ج چ ڇ ح خ د ڈ ذ ر ڑ ژ ز ڙ س ش ݜ ص ض ط ظ ع غ ک گ ف ق ل م ن ں ہ ء ے ی بھ پھ تھ ٹھ جھ چھ ڇھ دھ ڈھ ڑھ ڙھ کھ گھ لھ مھ نھ```
 
 ### Sample
 <!-- {{SENTENCES_SAMPLE}} -->
-There follows a randomly selected sample of five sentences from the corpus.
-تُوال شیِد ہُو ماشو آ کھأ بُورئی انگولا، مھیرے ݜا ئے تھیلی، ہے مھی شیرین لُوپٹا دُو زر تُوال ہُوئی شیِد ایگی سیدُو سی باچا،  تھامُوڑ جأن چھی، نی ہی ئی دھیریِنا وا پنا مُھن وطن سی دارُو تھی شیِدل اُو او ہوا، کھأو دُھو وطنا خلگ یدی حسینا  مُھن وطن قیمتی اب او ہوا ہی صفا، اُوتھل کھن سی پُوشُوا سی خائست غلبا آ ما برے نیِل تھام تُھو، مأ بھئنیِن چھیِجولا،  بُوڑ بندی شُویودُو، تُو دھرئی تأنا آرزئیل یأ باغوان یدُو پُوشُو چرڑا، میِا کأرتے نیدُو اصیل مامیرا  
+There follows a randomly selected sample of eleven sentences from the corpus.
+```
+تُوال شیِد ہُو ماشو آ کھأ بُورئی انگولا،
+مھیرے ݜا ئے تھیلی،
+ہے مھی شیرین لُوپٹا دُو زر تُوال ہُوئی شیِد ایگی سیدُو سی باچا،
+تھامُوڑ جأن چھی،
+نی ہی ئی دھیریِنا وا پنا مُھن وطن سی دارُو تھی شیِدل اُو او ہوا،
+کھأو دُھو وطنا خلگ یدی حسینا  مُھن وطن قیمتی اب او ہوا ہی صفا،
+اُوتھل کھن سی پُوشُوا سی خائست غلبا آ ما برے نیِل تھام تُھو،
+مأ بھئنیِن چھیِجولا،
+بُوڑ بندی شُویودُو،
+تُو دھرئی تأنا آرزئیل یأ باغوان یدُو پُوشُو چرڑا،
+میِا کأرتے نیدُو اصیل مامیرا
+```
 
 ### Sources
 <!-- {{SOURCES_LIST}} -->
 <!-- @ OPTIONAL @ -->
 <!-- A list of sentence sources, can be curated to the top-N -->
 
-1. Torwali-Urdu-English Dictionary by Idara Baraye Taleem wa Taraqi (IBT) 2. Torwali-English Dictionary for Students by Idara Baraye Taleem wa Taraqi (IBT) 3. Torwali Folktales by Idara Baraye Taleem wa Taraqi (IBT) 4. Torwali children’s books by Idara Baraye Taleem wa Taraqi (IBT) 5. Inaan 1 by Idara Baraye Taleem wa Taraqi (IBT) 6. Inaan 2 by Idara Baraye Taleem wa Taraqi (IBT) 7. Jinnah si Qisa by Idara Baraye Taleem wa Taraqi (IBT) 8. Fatima Jinnah si Qisa by Idara Baraye Taleem wa Taraqi (IBT) 9. Allama Iqbal si Qisia by Idara Baraye Taleem wa Taraqi (IBT) 10. Kashmala by Idara Baraye Taleem wa Taraqi (IBT) 11. Sultan Bahu Si Qisa by Idara Baraye Taleem wa Taraqi (IBT) 12. Surat-e-Rahman si Tarjuma by Idara Baraye Taleem wa Taraqi (IBT) 13. Akhrir Dash Surata- si An Nimaaz si Tarjuma by Idara Baraye Taleem wa Taraqi (IBT) 14. Poetry by Javid Iqbal Torwali ‘ 15. Poetry by Zubair Torwali  16. Essays by Zubair Torwali  17. Essays by Aftab Ahmad  18. Essays by Nisar Ahmad Torwali  19. Essays by Rahim Sabir  20. Novel by Zubair Torwali  
+1. Torwali-Urdu-English Dictionary by Idara Baraye Taleem wa Taraqi (IBT) 
+2. Torwali-English Dictionary for Students by Idara Baraye Taleem wa Taraqi (IBT) 
+3. Torwali Folktales by Idara Baraye Taleem wa Taraqi (IBT) 
+4. Torwali children’s books by Idara Baraye Taleem wa Taraqi (IBT) 
+5. Inaan 1 by Idara Baraye Taleem wa Taraqi (IBT) 
+6. Inaan 2 by Idara Baraye Taleem wa Taraqi (IBT) 
+7. Jinnah si Qisa by Idara Baraye Taleem wa Taraqi (IBT) 
+8. Fatima Jinnah si Qisa by Idara Baraye Taleem wa Taraqi (IBT) 
+9. Allama Iqbal si Qisia by Idara Baraye Taleem wa Taraqi (IBT) 
+10. Kashmala by Idara Baraye Taleem wa Taraqi (IBT) 
+11. Sultan Bahu Si Qisa by Idara Baraye Taleem wa Taraqi (IBT) 
+12. Surat-e-Rahman si Tarjuma by Idara Baraye Taleem wa Taraqi (IBT) 
+13. Akhrir Dash Surata- si An Nimaaz si Tarjuma by Idara Baraye Taleem wa Taraqi (IBT) 
+14. Poetry by Javid Iqbal Torwali ‘ 
+15. Poetry by Zubair Torwali  
+16. Essays by Zubair Torwali  
+17. Essays by Aftab Ahmad  
+18. Essays by Nisar Ahmad Torwali  
+19. Essays by Rahim Sabir  
+20. Novel by Zubair Torwali  
 
 ### Text domains
 <!-- {{TEXT_DOMAIN_DESCRIPTION}} -->
@@ -90,12 +121,6 @@ General, Agriculture and Food, Automotive and Transport, Finance, Service and Re
 
 Audio recording of the text corpus 
 
-### Recommended post-processing
-<!-- {{RECOMMENDED_POSTPROCESSING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- What should people do before they use the data, for example Unicode normalisation -->
-
-To use it in AI
 
 ## Get involved!
 
@@ -105,14 +130,14 @@ To use it in AI
 <!-- @ OPTIONAL @ -->
 <!-- Links to community chats / fora -->
 
-WhatsApp group, https://ibtnorthpakistan.org/
+* [WhatsApp group](https://ibtnorthpakistan.org/)
 
 ### Discussions
 <!-- {{DISCUSSION_LINKS_LIST}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Any links to discussions, for example on Discourse or other fora or blogs can be included here -->
 
-https://web.facebook.com/share/p/177y8v6z3C/
+* [Facebook post with more information](https://web.facebook.com/share/p/177y8v6z3C/)
 
 ### Contribute
 <!-- {{CONTRIBUTE_LINKS_LIST}} -->
@@ -127,21 +152,13 @@ https://web.facebook.com/share/p/177y8v6z3C/
 <!-- {{DATASHEET_AUTHORS_LIST}} -->
 <!-- A list in the format of: Your Name <email@email.com> -->
 
-1. Zubair Torwali, email: ztorwali@gmail.com  2. Javid Iqbal Torwali, email: jitorwali@gmail.com  3. Nisar Ahmad Torwali email: ibtswat@gmail.com  4. Rahim Sabir, email: storwali@gmail.com  5. Aftab Ahmad email: aahmadangel@gmail.com  6. Sajad Ahmad email: sajadtorwali@gmail.com  
+* Zubair Torwali <ztorwali@gmail.com>
+* Javid Iqbal Torwali <jitorwali@gmail.com>
+* Nisar Ahmad Torwali <ibtswat@gmail.com>
+* Rahim Sabir <storwali@gmail.com>
+* Aftab Ahmad <ahmadangel@gmail.com>
+* Sajad Ahmad <sajadtorwali@gmail.com>
 
-### Citation guidelines
-<!-- {{CITATION_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- If you published a paper and would like people to cite it, you can include the BiBTeX here -->
-
-
-
-### Funding
-<!-- {{FUNDING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- If you received any funding, you can include the acknowledgement here -->
-
-Yes 
 
 ## Licence
 This dataset is released under the [Creative Commons Zero (CC-0)](https://creativecommons.org/public-domain/cc0/) licence. By downloading this data

--- a/cv-corpus/scs/23.0-2025-09-17/final/en/wbl.md
+++ b/cv-corpus/scs/23.0-2025-09-17/final/en/wbl.md
@@ -7,14 +7,15 @@ speech (13 hours validated) from 13 speakers.
 <!-- {{LANGUAGE_DESCRIPTION}} -->
 <!-- Provide a brief (1-2 paragraph) description of your language -->
 
-Wakhi or Wakhani is indigenously termed as K̃hikwor )contraction of Wuk̃hikwor). It's an old eastern Iranian or Iranic language within the Pamiri branch. Though, diasporas also live in Russia and Turkey as well as in the European, American an Australian continents, the Wakhi (or K̃hikwor)language is spoken indigenously in Pakistan,China, Afghanistan, Tajikistan and Kirghizistan.   
+Wakhi or Wakhani is indigenously termed as K̃hikwor (contraction of Wuk̃hikwor). It's an old eastern Iranian or Iranic language within the Pamiri branch. Though, diasporas also live in Russia and Turkey as well as in the European, American an Australian continents, the Wakhi (or K̃hikwor) language is spoken indigenously in Pakistan, China, Afghanistan, Tajikistan and Kirghizistan.   
 
-### Variants
+<!-- ### Variants -->
 <!-- {{VARIANT_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Describe the variants (MCV variants) of your language -->
 
-The dataset has two key distinct varieties: Hunza Wakhi and out of Hunza Wakhi varieties. Hunza Wakhi differs not only in terms of its accent but somehow in grammatical features, too. Wakhi speakers of Ghizer and Chitral district have relatively similar accent. The grammatical aspects of these districts share a greater amount of Wakhi variety with the adjacent countries of their indigenous settlements. However, it's important to recognize that the huge vocabularies in all countries also differ to a significant level from each other, especially within technological realm in addition to following the respective national languages and some other genuine considerations. 
+<!-- Original Answer: -->
+<!-- The dataset has two key distinct varieties: Hunza Wakhi and out of Hunza Wakhi varieties. Hunza Wakhi differs not only in terms of its accent but somehow in grammatical features, too. Wakhi speakers of Ghizer and Chitral district have relatively similar accent. The grammatical aspects of these districts share a greater amount of Wakhi variety with the adjacent countries of their indigenous settlements. However, it's important to recognize that the huge vocabularies in all countries also differ to a significant level from each other, especially within technological realm in addition to following the respective national languages and some other genuine considerations. -->
 
 ## Demographic information
 <!-- You can get a lot of the information in this section from https://analyzer.cv-toolbox.web.tr/browse -->
@@ -48,33 +49,42 @@ Self-declared age information, frequency refers to the number of clips annotated
 <!-- @ OPTIONAL @ -->
 <!-- An overview of the text corpus, with information such as average length (in characters and words) of validated sentences. -->
 
-The corpus has sentences of Hunza Wakhi and based on extensive anthropological and linguistic fieldwork in Pakistan, China, Afghanistan and Tajikistan.T
+The corpus has sentences of Hunza Wakhi and based on extensive anthropological and linguistic fieldwork in Pakistan, China, Afghanistan and Tajikistan.
 
 ### Writing system
 <!-- {{WRITING_SYSTEM_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- A description of the writing system (or writing systems) used in the text corpus -->
 
-The script used is Roman Anglicized writing system, which is the approved script by Wakhi Tajik Cultural Association (WTCA), Pakistan, an Ishkoman Wakhi Welfare Organization (IWWO).Through this script, the literate Wakhi people easily and happily interact with each other across the borders on social media forums: it thus facilitates their creativities, thought expression in textual form and binds them together. 
+The script used is Roman Anglicized writing system, which is the approved script by Wakhi Tajik Cultural Association (WTCA), Pakistan, an Ishkoman Wakhi Welfare Organization (IWWO). Through this script, the literate Wakhi people easily and happily interact with each other across the borders on social media forums: it thus facilitates their creativities, thought expression in textual form and binds them together. 
 
 #### Symbol table
 <!-- {{ALPHABET_TABLE}} -->
 <!-- @ OPTIONAL @ -->
 <!-- If the writing system is alphabetic, you can include the valid alphabet here -->
 
-D̃d̃ Dh Ee Ẽẽ Ff Gg Gh g̃h Ii Jj J̃j̃ Kk Kh K̃h Ll Mm Nn Oo Pp Qq Rr Ss Sh S̃h Tt T̃t̃ Th Uu Ũũ Vv Ww Yy Zz Zh Z̃hZ̃z̃. 
+```D̃d̃ Dh Ee Ẽẽ Ff Gg Gh g̃h Ii Jj J̃j̃ Kk Kh K̃h Ll Mm Nn Oo Pp Qq Rr Ss Sh S̃h Tt T̃t̃ Th Uu Ũũ Vv Ww Yy Zz Zh Z̃hZ̃z̃ ```
 
 ### Sample
 <!-- {{SENTENCES_SAMPLE}} -->
 There follows a randomly selected sample of five sentences from the corpus.
-Kum insone ki cẽ haq en k̃hat e disht, yowe k̃hũ Khũdhoy disht. Yemi ya inson ki yowes̃h aql-e bũnyodher bafig̃h et shakig̃hev yewerd. Agar ki aql-e ya jũz cam en nik̃hinden, insoni cẽ kũ haywon’v en  be lup darinda. Woz sakes̃h dem k̃hũ jahon insonev winen ki dẽ aql en qiti, cerenges̃h darinda wocen. Parwardigore haya dẽstan inson-e rũwes̃h e jũr k̃hak dẽstan, bihisht et dũz̃akh-e tasawũr ratk.
+```
+Kum insone ki cẽ haq en k̃hat e disht, yowe k̃hũ Khũdhoy disht.
+Yemi ya inson ki yowes̃h aql-e bũnyodher bafig̃h et shakig̃hev yewerd.
+Agar ki aql-e ya jũz cam en nik̃hinden, insoni cẽ kũ haywon’v en  be lup darinda.
+Woz sakes̃h dem k̃hũ jahon insonev winen ki dẽ aql en qiti, cerenges̃h darinda wocen.
+Parwardigore haya dẽstan inson-e rũwes̃h e jũr k̃hak dẽstan, bihisht et dũz̃akh-e tasawũr ratk.
+```
 
 ### Sources
 <!-- {{SOURCES_LIST}} -->
 <!-- @ OPTIONAL @ -->
 <!-- A list of sentence sources, can be curated to the top-N -->
 
-1) Texts (sentences) made out of my own brain (creation) during the assignment period.  2) Texts out of selected Wakhi poetries.  3) New Wakhi transcriptions (texts) of the interviews out of my extensive fieldwork in Pakistan, china, Afghanistan and Tajikistan. 4) Wakhi publications from formal website: www.fazalamin.com 
+1) Texts (sentences) made out of my own brain (creation) during the assignment period.
+2) Texts out of selected Wakhi poetries.
+3) New Wakhi transcriptions (texts) of the interviews out of my extensive fieldwork in Pakistan, china, Afghanistan and Tajikistan
+4) Wakhi publications from formal website: www.fazalamin.com 
 
 ### Text domains
 <!-- {{TEXT_DOMAIN_DESCRIPTION}} -->
@@ -82,20 +92,6 @@ Kum insone ki cẽ haq en k̃hat e disht, yowe k̃hũ Khũdhoy disht. Yemi ya 
 <!-- What text domains are represented in the corpus? -->
 
 General
-
-### Processing
-<!-- {{PROCESSING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- How has the text data been processed -->
-
-
-
-### Recommended post-processing
-<!-- {{RECOMMENDED_POSTPROCESSING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- What should people do before they use the data, for example Unicode normalisation -->
-
-
 
 ## Get involved!
 
@@ -105,20 +101,26 @@ General
 <!-- @ OPTIONAL @ -->
 <!-- Links to community chats / fora -->
 
-There are uncountable social media forums (FaceBook, YouTube channels, or Insta) made with the name of Wakhi or in Wakhi language and cultural context. I can’t rmember all. Here, I’m offering some  of them, where I normally post the links of my creative work published on my website or YouTube channels.  It becomes  difficult for a visually disabled peron like me to   trace out the links of them. I’m just mentioing their names.  FaceBook (FB) Page of Wakhi Tajik Cultural Association (WTCA) FB Page of K̃hikwor Zik-e Razhek  FB Page of PamirTimes  FB Group of K̃hik Dũnyo (Wakhi World) FB Group of Wuk̃h TV (Wux TV) FB Group of Wakhi Research Center  FB Group of Wakhan Corridor  FB Group of Wakhi Music  FB Group of Wakhi Crowd  FB Group of Pamirs  YouTube Channel of  Wakhi Tajik Cultural Association (WTCA) YouTube channel of Pamir Television  
+There are uncountable social media forums (FaceBook, YouTube channels, or Insta) made with the name of Wakhi or in Wakhi language and cultural context. I can’t rmember all. Here, I’m offering some  of them, where I normally post the links of my creative work published on my website or YouTube channels.  It becomes  difficult for a visually disabled peron like me to trace out the links of them. I’m just mentioing their names.
+* FaceBook (FB) Page of Wakhi Tajik Cultural Association (WTCA) 
+* FB Page of K̃hikwor Zik-e Razhek  
+* FB Page of PamirTimes  
+* FB Group of K̃hik Dũnyo (Wakhi World) 
+* FB Group of Wuk̃h TV (Wux TV) 
+* FB Group of Wakhi Research Center  
+* FB Group of Wakhan Corridor  
+* FB Group of Wakhi Music  
+* FB Group of Wakhi Crowd  
+* FB Group of Pamirs  
+* YouTube Channel of  Wakhi Tajik Cultural Association (WTCA) 
+* YouTube channel of Pamir Television
 
-### Discussions
-<!-- {{DISCUSSION_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Any links to discussions, for example on Discourse or other fora or blogs can be included here -->
-
-
+http://www.fazalamin.com 
 
 ### Contribute
 <!-- {{CONTRIBUTE_LINKS_LIST}} -->
 <!-- Here you can include links for how to contribute to the dataset -->
 
-http://www.fazalamin.com 
 
 ## Acknowledgements
 
@@ -127,13 +129,10 @@ http://www.fazalamin.com
 <!-- {{DATASHEET_AUTHORS_LIST}} -->
 <!-- A list in the format of: Your Name <email@email.com> -->
 
-Mazdak Beg, Ahmad Jami Sakhi, Mr. Amanullah , Fazal Amin Beg
-
-### Citation guidelines
-<!-- {{CITATION_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- If you published a paper and would like people to cite it, you can include the BiBTeX here -->
-
+* Mazdak Beg
+* Ahmad Jami Sakhi
+* Mr. Amanullah
+* Fazal Amin Beg
 
 
 ### Funding

--- a/cv-corpus/scs/23.0-2025-09-17/final/en/xhe.md
+++ b/cv-corpus/scs/23.0-2025-09-17/final/en/xhe.md
@@ -9,12 +9,6 @@ speech (11 hours validated) from 11 speakers.
 
 Khetrani also called Khetranki is an Indo-Aryan language spoken in northeast Balochistan province of Pakistan mainly in Barkhan district but also in neighbouring districts, it is spoken by the Khetran people. About 200,000 people speak it.
 
-### Variants
-<!-- {{VARIANT_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Describe the variants (MCV variants) of your language -->
-
-NA
 
 ## Demographic information
 <!-- You can get a lot of the information in this section from https://analyzer.cv-toolbox.web.tr/browse -->
@@ -62,19 +56,15 @@ As the writing system of Khetrani language is Indo-Aryan (Indo-Arabic) similiar 
 <!-- @ OPTIONAL @ -->
 <!-- If the writing system is alphabetic, you can include the valid alphabet here -->
 
-ا ب پ ت ٹ ث ج چ ح خ د ذ ڈ ر ڑ ز ژ س ش ص ض ط ظ ع غ ف ق ک گ ل م ن و ہ ء ی ے ٻ ڄ ڋ ڳ ݨ
+```ا ب پ ت ٹ ث ج چ ح خ د ذ ڈ ر ڑ ز ژ س ش ص ض ط ظ ع غ ف ق ک گ ل م ن و ہ ء ی ے ٻ ڄ ڋ ڳ ݨ```
 
 ### Sample
 <!-- {{SENTENCES_SAMPLE}} -->
-There follows a randomly selected sample of five sentences from the corpus.
+There follows a randomly selected sample of sentences from the corpus.
+```
 ظالم تا ہِک مُنشی ہا ظالم کم تا ٻُجھا ہِے ذال ہِک دُکان ݙے ڳئی ہِے کہ اَسے شیر ݙے ون٘ڄوں بیگھاوا آں ہِے
+```
 
-### Sources
-<!-- {{SOURCES_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- A list of sentence sources, can be curated to the top-N -->
-
-NA
 
 ### Text domains
 <!-- {{TEXT_DOMAIN_DESCRIPTION}} -->
@@ -88,37 +78,16 @@ General, Language Fundamentals (e.g. Digits, Letters, Money)
 <!-- @ OPTIONAL @ -->
 <!-- How has the text data been processed -->
 
-To create the corpus the Khetrani native speakers generated the sentences by themselves .
-
-### Recommended post-processing
-<!-- {{RECOMMENDED_POSTPROCESSING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- What should people do before they use the data, for example Unicode normalisation -->
-
-NA
+To create the corpus the Khetrani native speakers generated the sentences by themselves.
 
 ## Get involved!
 
-
-### Community links
-<!-- {{COMMUNITY_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Links to community chats / fora -->
-
-NA
-
-### Discussions
-<!-- {{DISCUSSION_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Any links to discussions, for example on Discourse or other fora or blogs can be included here -->
-
-NA
 
 ### Contribute
 <!-- {{CONTRIBUTE_LINKS_LIST}} -->
 <!-- Here you can include links for how to contribute to the dataset -->
 
-NA
+
 
 ## Acknowledgements
 
@@ -127,14 +96,10 @@ NA
 <!-- {{DATASHEET_AUTHORS_LIST}} -->
 <!-- A list in the format of: Your Name <email@email.com> -->
 
-Muhammad Hussain <mhussainhassni1@gmail.com> Mubasher Kaleem <mubasherkaleem@gmail.com> Meesum Alam <Meesum.alam12@gmail.com>
+* Muhammad Hussain <mhussainhassni1@gmail.com>
+* Mubasher Kaleem <mubasherkaleem@gmail.com>
+* Meesum Alam <meesum.alam12@gmail.com>
 
-### Citation guidelines
-<!-- {{CITATION_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- If you published a paper and would like people to cite it, you can include the BiBTeX here -->
-
-NA
 
 ### Funding
 <!-- {{FUNDING_DESCRIPTION}} -->

--- a/cv-corpus/scs/23.0-2025-09-17/final/en/ydg.md
+++ b/cv-corpus/scs/23.0-2025-09-17/final/en/ydg.md
@@ -9,12 +9,13 @@ speech (11 hours validated) from 15 speakers.
 
 Yadgha (ISO 639-3: ydg), also known as Lutkohiwar, is spoken in the Lutkoh Valley, situated approximately 46 km west of Chitral town. The Yadgha people trace their origins to the Munjan valley in Afghanistan, having migrated to the Lutkoh Valley 31 generations ago. The Yadgha community consists of around 6,000 speakers, although this number is gradually decreasing. Speakers of the language are shifting to Khowar, the lingua franca of Chitral valley.  Yadgha is a written language, and several poets compose poetry in it. However, limited literacy activities are currently underway to support the language's preservation
 
-### Variants
+<!-- ### Variants -->
 <!-- {{VARIANT_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Describe the variants (MCV variants) of your language -->
 
-There is no different variety of the language. 
+<!-- Original Answer: -->
+<!-- There is no different variety of the language. -->
 
 ## Demographic information
 <!-- You can get a lot of the information in this section from https://analyzer.cv-toolbox.web.tr/browse -->
@@ -48,33 +49,35 @@ Self-declared age information, frequency refers to the number of clips annotated
 <!-- @ OPTIONAL @ -->
 <!-- An overview of the text corpus, with information such as average length (in characters and words) of validated sentences. -->
 
-The text came from my own writing.  The number of sentences are 2000
+The text came from my own writing.  The number of sentences are 2000.
 
 ### Writing system
 <!-- {{WRITING_SYSTEM_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- A description of the writing system (or writing systems) used in the text corpus -->
 
-The writing of Yadgha language is Perso-Arabic, develop by the community with support of Forum for language initiatives, a few years back 
+The writing of Yadgha language is Perso-Arabic, develop by the community with support of Forum for language initiatives, a few years back.
 
 #### Symbol table
 <!-- {{ALPHABET_TABLE}} -->
 <!-- @ OPTIONAL @ -->
 <!-- If the writing system is alphabetic, you can include the valid alphabet here -->
 
-آ ا ب پ ت ٹ ث ج چ ح خ ݯ ځ څ ݮ د ذ ر ز ڑ ژ ݱ س ش ݰ ص ض ط ظ ع غ ف ڤ ک گ ګ م ن ں و ہ ة ھ ء ی ے
+```آ ا ب پ ت ٹ ث ج چ ح خ ݯ ځ څ ݮ د ذ ر ز ڑ ژ ݱ س ش ݰ ص ض ط ظ ع غ ف ڤ ک گ ګ م ن ں و ہ ة ھ ء ی ے```
 
 ### Sample
 <!-- {{SENTENCES_SAMPLE}} -->
-There follows a randomly selected sample of five sentences from the corpus.
+There follows a randomly selected sample of sentences from the corpus.
+```
 نَمن یاغو شَماؤ نغن غور ڤے انسان خدان پیدا کڑے تو چر زیمونے نے ہورغن تیار اوئے
+```
 
 ### Sources
 <!-- {{SOURCES_LIST}} -->
 <!-- @ OPTIONAL @ -->
 <!-- A list of sentence sources, can be curated to the top-N -->
 
-I wrote sentences are my own. There is very few written material of the language. Those are world list and alphabet book
+I wrote sentences are my own. There is very few written material of the language. Those are world list and alphabet book.
 
 ### Text domains
 <!-- {{TEXT_DOMAIN_DESCRIPTION}} -->
@@ -90,28 +93,8 @@ General
 
 I wrote the sentences my own. I am a poet of the language and usually do write my poetry. Using the skill I develop the corpus that comprised on various general topics. 
 
-### Recommended post-processing
-<!-- {{RECOMMENDED_POSTPROCESSING_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- What should people do before they use the data, for example Unicode normalisation -->
-
-
 
 ## Get involved!
-
-
-### Community links
-<!-- {{COMMUNITY_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Links to community chats / fora -->
-
-
-
-### Discussions
-<!-- {{DISCUSSION_LINKS_LIST}} -->
-<!-- @ OPTIONAL @ -->
-<!-- Any links to discussions, for example on Discourse or other fora or blogs can be included here -->
-
 
 
 ### Contribute
@@ -127,14 +110,7 @@ I wrote the sentences my own. I am a poet of the language and usually do write m
 <!-- {{DATASHEET_AUTHORS_LIST}} -->
 <!-- A list in the format of: Your Name <email@email.com> -->
 
-
-
-### Citation guidelines
-<!-- {{CITATION_DESCRIPTION}} -->
-<!-- @ OPTIONAL @ -->
-<!-- If you published a paper and would like people to cite it, you can include the BiBTeX here -->
-
-
+Common Voice Community
 
 ### Funding
 <!-- {{FUNDING_DESCRIPTION}} -->


### PR DESCRIPTION
Revised datasheet files for kw, kxp, lrk, mcf, mki, mve, mvy, nhi, nn-NO, phl, phr, sbn, scl, sd, ssi, trw, wbl, xhe, ydg.
Datasheet plk was not modified, as the answers are not written in English.

Notes:
* kw and nn-NO had demographic tables that were deleted, as these will be auto-generated later
* kxp included sample sentences written in English. These were left unedited but should be deleted
* kxp had a symbol table of length 3, which is likely invalid
* Many datasheets (lrk, mvy, phr, sbn, sd, ssi, xhe, ydg) had no punctuation in their sample sentences. Because of this, I could not format the sample sentences as a list. I left the entire text in a block.
* lrk and ssi had some sections with non-English text. I commented these responses out. As plk was entirely not in English, the file was skipped.
* wbl had response text in the links section instead of links. I left this description intact