### PR TITLE
temporary provide english datasheets for Formosan languages

### DIFF
--- a/cv-corpus/scs/23.0-2025-09-05/final/en/bnn.md
+++ b/cv-corpus/scs/23.0-2025-09-05/final/en/bnn.md
@@ -2,27 +2,28 @@
 > This datasheet has been generated automatically, we would love to include more information, if you would like to help out, [get in touch](https://github.com/common-voice/common-voice/blob/main/docs/COMMUNITIES.md)!
 
  This datasheet is for version 23.0 of the the Mozilla Common Voice *Scripted Speech* dataset 
-for Bunun (布農語, `bnn`). The dataset contains 8220 clips representing 12 hours of recorded
+for Bunun (`bnn`). The dataset contains 8220 clips representing 12 hours of recorded
 speech (11 hours validated) from 18 speakers.
-錄音範圍為十二年國教課程原住民族語文教材第 1 至 9 階課文文本。
+
+The recordings cover the Indigenous Languages Curriculum (K-12) textbook materials, level 1 to 9.
 
 ## Language
 <!-- {{LANGUAGE_DESCRIPTION}} -->
 <!-- Provide a brief (1-2 paragraph) description of your language -->
-布農語（Bunun），臺灣原住民布農族的語言
+Bunun is the language of the Bunun people, one of the Indigenous peoples of Taiwan.
 
 ### Variants
 <!-- {{VARIANT_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Describe the variants (MCV variants) of your language -->
 
-本語音語料庫包含以下方言語群
+This speech corpus includes the following dialect groups:
 
-- 卓群布農語 Takituduh (`takitudu`)
-- 卡群布農語 Takibakha (`bakha`)
-- 郡群布農語 Isbukun (`bubukun`)
-- 巒群布農語 Takbanuaz (`banuaz`)
-- 丹群布農語 Takivatan (`vatan`)
+- Takituduh (`takitudu`)
+- Takibakha (`bakha`)
+- Isbukun (`bubukun`)
+- Takbanuaz (`banuaz`)
+- Takivatan (`vatan`)
 
 ## Demographic information
 The dataset includes the following distribution of age and gender.
@@ -31,7 +32,7 @@ The dataset includes the following distribution of age and gender.
 ### Gender
 Self-declared gender information, percentage refers to the number of clips annotated with this gender.
 
-（2025 年初 MozTW / 台灣維基協會族語錄音專案，並未登錄此資訊，故此資料相對不準確。）
+(The MozTW / Wikimedia Taiwan Indigenous language recording project in early 2025 did not collect this information; therefore, these figures may be relatively inaccurate.)
 
 | Gender | Pertentage |
 |-|-|
@@ -50,7 +51,7 @@ Self-declared gender information, percentage refers to the number of clips annot
 ### Age
 Self-declared age information, percentage refers to the number of clips annotated with this age band.
 
-（2025 年初 MozTW / 台灣維基協會的族語錄音專案，並未登錄此資訊，故此資料相對不準確。）
+(The MozTW / Wikimedia Taiwan Indigenous language recording project in early 2025 did not collect this information; therefore, these figures may be relatively inaccurate.)
 
 | Age Band | Percentage |
 |-|-|
@@ -110,11 +111,11 @@ Asa tu makadim mas haini-anan, aupa kadukuun laupakadau a hanian
 <!-- @ OPTIONAL @ -->
 <!-- A list of sentence sources, can be curated to the top-N -->
 
-錄音文本取自《十二年國教原住民族語文教材》第一至九階課文之族語（羅馬字）內容，經[中華民國教育部國民及學前教育署](https://www.k12ea.gov.tw)（K-12 Education Administration, Ministry of Education, Taiwan ROC）授權，由台灣維基媒體協會整理後上傳。特別感謝時任教育部政務次長葉丙成協助協調授權事宜。
+The recording texts are taken from the Indigenous Languages Curriculum (K-12) textbook content (in romanization) for stages 1 to 9. They were uploaded by Wikimedia Taiwan under authorization from the K-12 Education Administration, Ministry of Education (Taiwan, ROC) at https://www.k12ea.gov.tw. Special thanks to Deputy Minister Ping-Cheng Yeh for facilitating the authorization.
 
-郡群布農語另包含[布農語聖經](https://cb.fhl.net)選句共 118 句，感謝財團法人台灣聖經公會（The Bible Society in Taiwan）授權。
+For the Isbukun dialect, 118 selected verses from the Bunun Bible (see https://cb.fhl.net) are also included, thanks to authorization by The Bible Society in Taiwan.
 
-在族語專案錄音過程中，我們發現部分文本存在文意不符、單詞或拼寫錯誤等情況。因 Common Voice 系統限制，相關內容未能事先更正仍直接進行錄製。錄音者與教材之間是為共同協作關係，特此說明。
+During the recording project, we noticed that some text contained semantic mismatches or typographical/spelling mistakes. Due to Common Voice system constraints, these issues could not be fixed in advance and recordings proceeded as-is. Recorders and textbook providers collaborated closely; we note this for transparency.
 
 ### Text domains
 | Domain | Count |
@@ -162,25 +163,25 @@ information.
 <!-- @ OPTIONAL @ -->
 <!-- Links to community chats / fora -->
 
-Mozilla 台灣社群 (MozTW) Common Voice 專案網站： [https://moztw.org/commonvoice/](https://moztw.org/commonvoice/)
+MozTW (Mozilla Taiwan) Common Voice project site: https://moztw.org/commonvoice/
 
-任何問題與建議、協助推廣、捐贈語料，或其他合作需求，請透過以下社群頻道與我們討論：
+For questions, suggestions, outreach, donating text, or collaboration, please reach out via:
 
-- [Telegram group](https://t.me/+gvmHEcAtd-IwNzFl)
-- [Line group](https://line.me/ti/g/_PLyjCSe_8)
+- Telegram group: https://t.me/+gvmHEcAtd-IwNzFl
+- Line group: https://line.me/ti/g/_PLyjCSe_8
 
-2025 族語錄音計畫參與社群：
+Communities involved in the 2025 Indigenous language recording project:
 
-- [台灣維基媒體協會 (Wikimedia Taiwan)](https://www.facebook.com/wikimedia.tw)
-- 特別感謝布農族 Aping 伍阿好老師協助
+- Wikimedia Taiwan: https://www.facebook.com/wikimedia.tw
+- Special thanks to Bunun teacher Aping (Wu A-Hao) for her support
 
 ### Discussions
 <!-- {{DISCUSSION_LINKS_LIST}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Any links to discussions, for example on Discourse or other fora or blogs can be included here -->
 
-* [Discourse 討論區](https://discourse.mozilla.org/c/voice/zh-tw/286)
-* [相關新聞](https://hackmd.io/@moztw/common-voice-news)
+* Discourse forum (zh-TW): https://discourse.mozilla.org/c/voice/zh-tw/286
+* Related news: https://hackmd.io/@moztw/common-voice-news
 
 ### Contribute
 * [Speak](https://commonvoice.mozilla.org/bnn/speak)
@@ -195,7 +196,7 @@ Mozilla 台灣社群 (MozTW) Common Voice 專案網站： [https://moztw.org/com
 <!-- {{DATASHEET_AUTHORS_LIST}} -->
 <!-- A list in the format of: Your Name <email@email.com> -->
 
-- Irvin Chen (MozTW 社群聯絡人) <irvin@moztw.org>
+- Irvin Chen (MozTW Community Contact) <irvin@moztw.org>
 
 ### Citation guidelines
 <!-- {{CITATION_DESCRIPTION}} -->

--- a/cv-corpus/scs/23.0-2025-09-05/final/en/dru.md
+++ b/cv-corpus/scs/23.0-2025-09-05/final/en/dru.md
@@ -2,28 +2,27 @@
 > This datasheet has been generated automatically, we would love to include more information, if you would like to help out, [get in touch](https://github.com/common-voice/common-voice/blob/main/docs/COMMUNITIES.md)!
 
  This datasheet is for version 23.0 of the the Mozilla Common Voice *Scripted Speech* dataset 
-for Rukai (`dru`), 含茂林語 (Teldreka), 萬山語 ('Oponoho). The dataset contains 6692 clips representing 11 hours of recorded
+for Rukai (`dru`) (including Teldreka and 'Oponoho). The dataset contains 6692 clips representing 11 hours of recorded
 speech (11 hours validated) from 20 speakers.
 
-本語料集包含排灣經典工作室協助招募的魯凱族，以及茂林及萬山語社群總計 20 位錄音者。
-錄音範圍為十二年國教課程原住民族語文教材第 1 至 9 階課文文本。
+This dataset includes 20 speakers from the Rukai community recruited with support from Payuan Classic Studio, as well as speakers from the Teldreka and Oponoho communities. The recordings cover the Indigenous Languages Curriculum (K-12) textbook materials, level 1 to 9.
 
 ## Language
 <!-- {{LANGUAGE_DESCRIPTION}} -->
 <!-- Provide a brief (1-2 paragraph) description of your language -->
-魯凱語（Drekay）、茂林語（Teldreka）、萬山語（'Oponoho），臺灣原住民魯凱族的語言
+Rukai (Drekay), including Teldreka and Oponoho, are Indigenous languages of the Rukai people in Taiwan.
 
 ### Variants
 <!-- {{VARIANT_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Describe the variants (MCV variants) of your language -->
-本語音語料庫包含以下方言語群
+This speech corpus includes the following dialect groups:
 
-- 東魯凱語 Eastern Rukai (`taromak`)
-- 霧臺魯凱語 Wutai Rukai (`veday`)
-- 大武魯凱語 Dawu Rukai (`labuane`)
-- 萬山語 Oponoho (`oponoho`)
-- 茂林語 Teldreka (`teldreka`)
+- Eastern Rukai (`taromak`)
+- Wutai Rukai (`veday`)
+- Dawu Rukai (`labuane`)
+- Oponoho (`oponoho`)
+- Teldreka (`teldreka`)
 
 ## Demographic information
 The dataset includes the following distribution of age and gender.
@@ -32,7 +31,7 @@ The dataset includes the following distribution of age and gender.
 ### Gender
 Self-declared gender information, percentage refers to the number of clips annotated with this gender.
 
-（2025 年初 MozTW / 台灣維基協會族語錄音專案，並未登錄此資訊，故此資料相對不準確。）
+(The MozTW / Wikimedia Taiwan Indigenous language recording project in early 2025 did not collect this information; therefore, these figures may be relatively inaccurate.)
 
 | Gender | Pertentage |
 |-|-|
@@ -49,7 +48,7 @@ Self-declared gender information, percentage refers to the number of clips annot
 ### Age
 Self-declared age information, percentage refers to the number of clips annotated with this age band.
 
-（2025 年初 MozTW / 台灣維基協會族語錄音專案，並未登錄此資訊，故此資料相對不準確。）
+(The MozTW / Wikimedia Taiwan Indigenous language recording project in early 2025 did not collect this information; therefore, these figures may be relatively inaccurate.)
 
 | Age Band | Percentage |
 |-|-|
@@ -108,13 +107,13 @@ Taiwan ka ’iyakay nyani madraw na egeege?
 <!-- @ OPTIONAL @ -->
 <!-- A list of sentence sources, can be curated to the top-N -->
 
-錄音文本取自《十二年國教原住民族語文教材》第一至九階課文之族語（羅馬字）內容，經[中華民國教育部國民及學前教育署](https://www.k12ea.gov.tw)（K-12 Education Administration, Ministry of Education, Taiwan ROC）授權，由台灣維基媒體協會整理後上傳。特別感謝時任教育部政務次長葉丙成協助協調授權事宜。
+The recording texts are taken from the Indigenous Languages Curriculum (K-12) textbook content (in romanization) for levels 1 to 9, uploaded by Wikimedia Taiwan under authorization from the K-12 Education Administration, Ministry of Education (Taiwan, ROC): https://www.k12ea.gov.tw. Special thanks to Deputy Minister Ping-Cheng Yeh for facilitating the authorization.
 
-部分霧台魯凱語（`veday`）文本，由國⽴台灣⼤學語⾔學研究所《[台⼤台灣南島語語料庫](https://corpus.linguistics.ntu.edu.tw/)》（NTU Corpus of Formosan Languages, Graduate Institute of Linguistics, National Taiwan University）提供。感謝宋麗梅老師協助。
+Some Wutai Rukai (`veday`) texts are provided by the NTU Corpus of Formosan Languages (Graduate Institute of Linguistics, National Taiwan University): https://corpus.linguistics.ntu.edu.tw/ (thanks to Prof. Li-May Sung for assistance).
 
-多納語、萬山語、茂林語另包含[馬可福音](https://cb.fhl.net)選句各 59 句，感謝財團法人台灣聖經公會（The Bible Society in Taiwan）授權。
+For Tona, Oponoho and Teldreka, 59 selected verses each from the Gospel of Mark (see https://cb.fhl.net) are included, with authorization from The Bible Society in Taiwan.
 
-在族語專案錄音過程中，我們發現部分文本存在文意不符、單詞或拼寫錯誤等情況。因 Common Voice 系統限制，相關內容未能事先更正仍直接進行錄製。錄音者與教材之間是為共同協作關係，特此說明。
+During the recording project, we noticed certain semantic mismatches and typographical/spelling issues in parts of the text. Due to Common Voice system constraints, these were not corrected in advance and recordings proceeded as-is. Recorders and textbook providers collaborated closely; this note is provided for transparency.
 
 ### Text domains
 | Domain | Count |
@@ -160,18 +159,18 @@ information.
 
 ### Community links
 
-Mozilla 台灣社群 (MozTW) Common Voice 專案網站： [https://moztw.org/commonvoice/](https://moztw.org/commonvoice/)
+MozTW (Mozilla Taiwan) Common Voice project site: https://moztw.org/commonvoice/
 
-任何問題與建議、協助推廣、捐贈語料，或其他合作需求，請透過以下社群頻道與我們討論：
+For questions, suggestions, outreach, donating text, or collaboration, please reach out via:
 
-- [Telegram group](https://t.me/+gvmHEcAtd-IwNzFl)
-- [Line group](https://line.me/ti/g/_PLyjCSe_8)
+- Telegram group: https://t.me/+gvmHEcAtd-IwNzFl
+- Line group: https://line.me/ti/g/_PLyjCSe_8
 
-2025 族語錄音計畫參與社群：
+Communities involved in the 2025 Indigenous language recording project:
 
-- [台灣維基媒體協會 (Wikimedia Taiwan)](https://www.facebook.com/wikimedia.tw)
-- [排灣經典 Payuan Classic](https://www.facebook.com/PayuanClassic/)
-- 特別感謝排灣經典葉王靖 kuliw 協助招募與錄音事宜
+- Wikimedia Taiwan: https://www.facebook.com/wikimedia.tw
+- Payuan Classic: https://www.facebook.com/PayuanClassic/
+- Special thanks to Kuliw from Payuan Classic for recruitment and recording support
 - 
 <!-- {{COMMUNITY_LINKS_LIST}} -->
 <!-- @ OPTIONAL @ -->
@@ -182,8 +181,8 @@ Mozilla 台灣社群 (MozTW) Common Voice 專案網站： [https://moztw.org/com
 <!-- @ OPTIONAL @ -->
 <!-- Any links to discussions, for example on Discourse or other fora or blogs can be included here -->
 
-* [Discourse 討論區](https://discourse.mozilla.org/c/voice/zh-tw/286)
-* [相關新聞](https://hackmd.io/@moztw/common-voice-news)
+* Discourse forum (zh-TW): https://discourse.mozilla.org/c/voice/zh-tw/286
+* Related news: https://hackmd.io/@moztw/common-voice-news
 
 ### Contribute
 * [Speak](https://commonvoice.mozilla.org/dru/speak)
@@ -196,7 +195,7 @@ Mozilla 台灣社群 (MozTW) Common Voice 專案網站： [https://moztw.org/com
 ### Datasheet authors
 <!-- {{DATASHEET_AUTHORS_LIST}} -->
 <!-- A list in the format of: Your Name <email@email.com> -->
- - Irvin Chen (MozTW 社群聯絡人) <irvin@moztw.org>
+ - Irvin Chen (MozTW Community Contact) <irvin@moztw.org>
 
 ### Citation guidelines
 <!-- {{CITATION_DESCRIPTION}} -->

--- a/cv-corpus/scs/23.0-2025-09-05/final/en/nan-tw.md
+++ b/cv-corpus/scs/23.0-2025-09-05/final/en/nan-tw.md
@@ -5,28 +5,28 @@
 for Taiwanese (Minnan) (`nan-tw`). The dataset contains 31951 clips representing 24 hours of recorded
 speech (21 hours validated) from 290 speakers.
 
-請特別注意：本語音語料集為「*漢字——語音資料集*」。
-本語料集文本語料以漢字為主，同時括號標注台羅或白話字參考發音。
+Please note: This speech dataset is a Han character–speech dataset.
+The text corpus primarily uses Han characters, with bracketed TL/POJ romanization as reference pronunciations.
 
-本語料及錄音者為主要來自台灣的個別志工參與者。
+The corpus and speakers are primarily contributed by individual volunteers in Taiwan.
 
 ## Language
 <!-- {{LANGUAGE_DESCRIPTION}} -->
 <!-- Provide a brief (1-2 paragraph) description of your language -->
 
-臺灣話（白話字：Tâi-oân-ōe；臺羅：Tâi-uân-uē），又稱為台語／臺語或臺灣閩南語，通行於臺灣及澎湖群島，中華民國（臺灣）國家語言之一。
+Taiwanese (POJ: Tâi-oân-ōe; TL: Tâi-uân-uē), also known as Tai-gi (台語/臺語) or Taiwanese Minnan (臺灣閩南語), is spoken across Taiwan and the Penghu archipelago, and is one of Taiwan’s national languages.
 
 ### Variants
 <!-- {{VARIANT_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Describe the variants (MCV variants) of your language -->
 
-於 v23.0 版本開始，Common Voice 台語版本允許錄音與文本貢獻者選擇（非必選）以下書寫系統變體（Variant）。但目前文本語料仍以兩者混合（非特定系統）為大宗。
+Starting from v23.0, the Taiwanese (nan-tw) locale allows (optional) selection of the following writing variants; however, most texts are still a mixture of both systems:
 
-- 白話字（POJ） (`pehoeji`)
-- 台羅（TL） (`tailo`)
+- POJ (`pehoeji`)
+- TL (`tailo`)
 
-如欲協助更新現有語料，請往下到 Community 欄目與我們聯繫。
+If you’d like to help curate or update the existing texts, please see the Community section below.
 
 ## Demographic information
 The dataset includes the following distribution of age and gender.
@@ -84,11 +84,11 @@ The text corpus contains `27277` sentences, of which `26907` are validated, `370
 <!-- @ OPTIONAL @ -->
 <!-- An overview of the text corpus, with information such as average length (in characters and words) of validated sentences. -->
 
-此錄音集大部分文本語料整理於：[MozTW CC0 語料庫](https://github.com/moztw/cc0-sentences)，主要來自 MozTW ／ g0v 社群個別參與者。
+Most of the text corpus was curated in the MozTW CC0 Sentences repository: https://github.com/moztw/cc0-sentences, primarily contributed by MozTW and g0v community members.
 
-由於目前缺乏公共授權（無已知授權限制）的台語「句子」文本語料，Common Voice 台語錄音目前以「單詞」為大宗。
+Due to the lack of publicly licensed Taiwanese sentences, recordings in the Taiwanese locale are currently dominated by single-word prompts.
 
-我們亟需更多「日常生活用句」，歡迎捐贈您以台語書寫的作品。請參考下方社群頻道資訊與我們聯繫。
+We welcome donations of everyday sentences written in Taiwanese. Please reach out via the community channels below.
 
 ### Writing system
 <!-- {{WRITING_SYSTEM_DESCRIPTION}} -->
@@ -117,9 +117,9 @@ There follows a randomly selected sample of five sentences from the corpus.
 <!-- @ OPTIONAL @ -->
 <!-- A list of sentence sources, can be curated to the top-N -->
 
-文本語料由 Mozilla 台灣社群、g0v 社群、及其他開放原始碼運動參與者共同建立。
+The text corpus is built by Mozilla Taiwan community, the g0v community, and other open-source contributors.
 
-早期的台語語料主要來自「2016-itaigi華台對照典」。請參考[資料來源與授權](https://github.com/moztw/cc0-sentences/tree/master/nan-TW#資料來源與授權)了解原始資料出處。
+Earlier Taiwanese entries were primarily sourced from the “2016-itaigi Mandarin–Taiwanese Dictionary”. See Sources and Licensing at: https://github.com/moztw/cc0-sentences/tree/master/nan-TW#%E8%B3%87%E6%96%99%E4%BE%86%E6%BA%90%E8%88%87%E6%8E%88%E6%AC%8A
 
 ### Text domains
 | Domain | Count |
@@ -135,9 +135,9 @@ There follows a randomly selected sample of five sentences from the corpus.
 <!-- @ OPTIONAL @ -->
 <!-- What text domains are represented in the corpus? -->
 
-由於目前缺乏公共授權的「句子」資料，Common Voice 台語語料目前仍以「單詞」為大宗。
+Due to the lack of publicly licensed sentence data, recordings in Taiwanese remain predominantly single words.
 
-我們亟需更多「日常生活用句」，歡迎捐贈您以台語書寫的作品。請參考 [社群頻道資訊](#community-links) 與我們聯繫。
+We welcome more everyday sentences. If you would like to donate your own text (e.g., your original writing), please contact us via the community links below.
 
 ### Processing
 <!-- {{PROCESSING_DESCRIPTION}} -->
@@ -149,9 +149,9 @@ There follows a randomly selected sample of five sentences from the corpus.
 <!-- @ OPTIONAL @ -->
 <!-- What should people do before they use the data, for example Unicode normalisation -->
 
-因為句子、單詞所標示的羅馬字為參考用，且 a) 混用台羅與白話字系統，b) 也未能標出所有腔調的發音，顧無法作為實際錄音者發音之對應標注。
+Because the bracketed romanization is for reference only and a) mixes TL and POJ systems, and b) does not consistently mark all tones, it cannot be treated as an authoritative phonetic annotation for the recordings.
 
-我們建議使用前先行移除用`（）`包夾的參考發音，僅取用漢字部分。
+We recommend removing bracketed pronunciations `（）` and using only the Han character portion when pre-processing the text.
 
 ### Fields
 Each row of a `tsv` file represents a single audio clip, and contains the following information:
@@ -180,25 +180,25 @@ information.
 <!-- @ OPTIONAL @ -->
 <!-- Links to community chats / fora -->
 
-Mozilla 台灣社群 (MozTW) Common Voice 專案網站： [https://moztw.org/commonvoice/](https://moztw.org/commonvoice/)
+MozTW (Mozilla Taiwan) Common Voice project site: https://moztw.org/commonvoice/
 
-任何問題與建議、協助推廣、捐贈語料，或其他合作需求，請透過以下社群頻道與我們討論：
+For questions, suggestions, outreach, donating text, or collaboration, please reach out via:
 
-- [Telegram group](https://t.me/+gvmHEcAtd-IwNzFl)
-- [Line group](https://line.me/ti/g/_PLyjCSe_8)
+- Telegram group: https://t.me/+gvmHEcAtd-IwNzFl
+- Line group: https://line.me/ti/g/_PLyjCSe_8
 
 ### Discussions
 <!-- {{DISCUSSION_LINKS_LIST}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Any links to discussions, for example on Discourse or other fora or blogs can be included here -->
 
-* [Discourse 討論區](https://discourse.mozilla.org/c/voice/zh-tw/286)
-* [相關新聞](https://hackmd.io/@moztw/common-voice-news)
+* Discourse forum (zh-TW): https://discourse.mozilla.org/c/voice/zh-tw/286
+* Related news: https://hackmd.io/@moztw/common-voice-news
 
 ### Contribute
 * [Speak](https://commonvoice.mozilla.org/nan-tw/speak)
 * [Listen](https://commonvoice.mozilla.org/nan-tw/listen)
-* 捐出你的句子 - 如您有意願捐出你擁有的文本語料（例如您的個人創作）供參與者錄音，請先聯絡 Irvin （ irvin@moztw.org ）或於以上 Line / Telegram 群組討論。
+* Donate your sentences — If you would like to donate text you own (e.g., original writing) for recording, please contact Irvin (irvin@moztw.org) or discuss in the Line/Telegram groups above.
 
 <!-- {{CONTRIBUTE_LINKS_LIST}} -->
 <!-- Here you can include links for how to contribute to the dataset -->
@@ -209,7 +209,7 @@ Mozilla 台灣社群 (MozTW) Common Voice 專案網站： [https://moztw.org/com
 <!-- {{DATASHEET_AUTHORS_LIST}} -->
 <!-- A list in the format of: Your Name <email@email.com> -->
 
- - Irvin Chen (MozTW 社群聯絡人) <irvin@moztw.org>
+ - Irvin Chen (MozTW Community Contact) <irvin@moztw.org>
  - Dennis Chen (Common Voice Community Facilitator, Wikimedia Taiwan) <dennis@wikimedia.tw>
 
 ### Citation guidelines

--- a/cv-corpus/scs/23.0-2025-09-05/final/en/pwn.md
+++ b/cv-corpus/scs/23.0-2025-09-05/final/en/pwn.md
@@ -5,23 +5,23 @@
 for Paiwan (`pwn`). The dataset contains 10938 clips representing 15 hours of recorded
 speech (15 hours validated) from 27 speakers.
 
-本語料集包含排灣經典工作室協助招募的 27 位錄音者，錄音範圍為十二年國教課程原住民族語文教材第 1 至 9 階課文文本。
+This dataset includes 27 speakers recruited with the support of Payuan Classic Studio. The recordings cover the Indigenous Languages Curriculum (K-12) textbook materials, level 1 to 9.
 
 ## Language
 <!-- {{LANGUAGE_DESCRIPTION}} -->
 <!-- Provide a brief (1-2 paragraph) description of your language -->
-排灣語（Pinayuanan），臺灣原住民排灣族的語言
+Paiwan (Pinayuanan) is an Indigenous language of the Paiwan people in Taiwan.
 
 ### Variants
 <!-- {{VARIANT_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Describe the variants (MCV variants) of your language -->
-本語音語料庫包含以下方言語群
+This speech corpus includes the following dialect groups:
 
-- 中排灣語 Central Paiwan (`central`)
-- 東排灣語 Eastern Paiwan (`eastern`)
-- 北排灣語 Northern Paiwan (`northern`)
-- 南排灣語 Southern Paiwan (`southern`)
+- Central Paiwan (`central`)
+- Eastern Paiwan (`eastern`)
+- Northern Paiwan (`northern`)
+- Southern Paiwan (`southern`)
 
 ## Demographic information
 The dataset includes the following distribution of age and gender.
@@ -30,7 +30,7 @@ The dataset includes the following distribution of age and gender.
 ### Gender
 Self-declared gender information, percentage refers to the number of clips annotated with this gender.
 
-（2025 年初 MozTW / 台灣維基協會族語錄音專案，並未登錄此資訊，故此資料相對不準確。）
+(The MozTW / Wikimedia Taiwan Indigenous language recording project in early 2025 did not collect this information; therefore, these figures may be relatively inaccurate.)
 
 | Gender | Pertentage |
 |-|-|
@@ -49,7 +49,7 @@ Self-declared gender information, percentage refers to the number of clips annot
 ### Age
 Self-declared age information, percentage refers to the number of clips annotated with this age band.
 
-（2025 年初 MozTW / 台灣維基協會族語錄音專案，並未登錄此資訊，故此資料相對不準確。）
+(The MozTW / Wikimedia Taiwan Indigenous language recording project in early 2025 did not collect this information; therefore, these figures may be relatively inaccurate.)
 
 | Age Band | Percentage |
 |-|-|
@@ -109,9 +109,9 @@ keman a ken tu tjanu ita tua udung
 <!-- {{SOURCES_LIST}} -->
 <!-- @ OPTIONAL @ -->
 <!-- A list of sentence sources, can be curated to the top-N -->
-錄音文本取自《十二年國教原住民族語文教材》第一至九階課文之族語（羅馬字）內容，經[中華民國教育部國民及學前教育署](https://www.k12ea.gov.tw)（K-12 Education Administration, Ministry of Education, Taiwan ROC）授權，由台灣維基媒體協會整理後上傳。特別感謝時任教育部政務次長葉丙成協助協調授權事宜。
+The recording texts are taken from the Indigenous Languages Curriculum (K-12) textbook content (in romanization) for levels 1 to 9, uploaded by Wikimedia Taiwan under authorization from the K-12 Education Administration, Ministry of Education (Taiwan, ROC): https://www.k12ea.gov.tw. Special thanks to Deputy Minister Ping-Cheng Yeh for facilitating the authorization.
 
-在族語專案錄音過程中，我們發現部分文本存在文意不符、單詞或拼寫錯誤等情況。因 Common Voice 系統限制，相關內容未能事先更正仍直接進行錄製。錄音者與教材之間是為共同協作關係，特此說明。
+During the recording project, we noticed certain semantic mismatches and typographical/spelling issues in parts of the text. Due to Common Voice system constraints, these were not corrected in advance and recordings proceeded as-is. Recorders and textbook providers collaborated closely; this note is provided for transparency.
 
 ### Text domains
 | Domain | Count |
@@ -154,18 +154,18 @@ information.
 ## Get involved!
 
 ### Community links
-Mozilla 台灣社群 (MozTW) Common Voice 專案網站： [https://moztw.org/commonvoice/](https://moztw.org/commonvoice/)
+MozTW (Mozilla Taiwan) Common Voice project site: https://moztw.org/commonvoice/
 
-任何問題與建議、協助推廣、捐贈語料，或其他合作需求，請透過以下社群頻道與我們討論：
+For questions, suggestions, outreach, donating text, or collaboration, please reach out via:
 
-- [Telegram group](https://t.me/+gvmHEcAtd-IwNzFl)
-- [Line group](https://line.me/ti/g/_PLyjCSe_8)
+- Telegram group: https://t.me/+gvmHEcAtd-IwNzFl
+- Line group: https://line.me/ti/g/_PLyjCSe_8
 
-2025 族語錄音計畫參與社群：
+Communities involved in the 2025 Indigenous language recording project:
 
-- [台灣維基媒體協會 (Wikimedia Taiwan)](https://www.facebook.com/wikimedia.tw)
-- [排灣經典 Payuan Classic](https://www.facebook.com/PayuanClassic/)
-- 特別感謝排灣經典葉王靖 kuliw 協助招募與錄音事宜
+- Wikimedia Taiwan: https://www.facebook.com/wikimedia.tw
+- Payuan Classic: https://www.facebook.com/PayuanClassic/
+- Special thanks to Kuliw for recruitment and recording support
 <!-- {{COMMUNITY_LINKS_LIST}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Links to community chats / fora -->
@@ -174,8 +174,8 @@ Mozilla 台灣社群 (MozTW) Common Voice 專案網站： [https://moztw.org/com
 <!-- {{DISCUSSION_LINKS_LIST}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Any links to discussions, for example on Discourse or other fora or blogs can be included here -->
-* [Discourse 討論區](https://discourse.mozilla.org/c/voice/zh-tw/286)
-* [相關新聞](https://hackmd.io/@moztw/common-voice-news)
+* Discourse forum (zh-TW): https://discourse.mozilla.org/c/voice/zh-tw/286
+* Related news: https://hackmd.io/@moztw/common-voice-news
 
 ### Contribute
 * [Speak](https://commonvoice.mozilla.org/pwn/speak)
@@ -189,7 +189,7 @@ Mozilla 台灣社群 (MozTW) Common Voice 專案網站： [https://moztw.org/com
 ### Datasheet authors
 <!-- {{DATASHEET_AUTHORS_LIST}} -->
 <!-- A list in the format of: Your Name <email@email.com> -->
- - Irvin Chen (MozTW 社群聯絡人) <irvin@moztw.org>
+ - Irvin Chen (MozTW Community Contact) <irvin@moztw.org>
 
 ### Citation guidelines
 <!-- {{CITATION_DESCRIPTION}} -->

--- a/cv-corpus/scs/23.0-2025-09-05/final/en/szy.md
+++ b/cv-corpus/scs/23.0-2025-09-05/final/en/szy.md
@@ -5,12 +5,12 @@
 for Sakizaya (`szy`). The dataset contains 9643 clips representing 15 hours of recorded
 speech (14 hours validated) from 26 speakers.
 
-本語料集包含花蓮縣撒奇萊雅族維基媒體協會的 26 位錄音者，錄音範圍為十二年國教課程原住民族語文教材第 1 至 9 階課文文本。
+This dataset includes 26 speakers from the Hualien Sakizaya Wikimedia Association. The recordings cover the Indigenous Languages Curriculum (K-12) textbook materials, level 1 to 9.
 
 ## Language
 <!-- {{LANGUAGE_DESCRIPTION}} -->
 <!-- Provide a brief (1-2 paragraph) description of your language -->
-撒奇萊雅語（Sakizaya），臺灣原住民撒奇萊雅族的語言
+Sakizaya is the language of the Sakizaya people, an Indigenous people of Taiwan.
 
 ### Variants
 <!-- {{VARIANT_DESCRIPTION}} -->
@@ -24,7 +24,7 @@ The dataset includes the following distribution of age and gender.
 ### Gender
 Self-declared gender information, percentage refers to the number of clips annotated with this gender.
 
-（2025 年初 MozTW / 台灣維基協會族語錄音專案，並未登錄此資訊，故此資料相對不準確。）
+(The MozTW / Wikimedia Taiwan Indigenous language recording project in early 2025 did not collect this information; therefore, these figures may be relatively inaccurate.)
 
 | Gender | Pertentage |
 |-|-|
@@ -42,7 +42,7 @@ Self-declared gender information, percentage refers to the number of clips annot
 ### Age
 Self-declared age information, percentage refers to the number of clips annotated with this age band.
 
-（2025 年初 MozTW / 台灣維基協會族語錄音專案，並未登錄此資訊，故此資料相對不準確。）
+(The MozTW / Wikimedia Taiwan Indigenous language recording project in early 2025 did not collect this information; therefore, these figures may be relatively inaccurate.)
 
 | Age Band | Percentage |
 |-|-|
@@ -104,11 +104,11 @@ micakay kaku tu sapisulit atu sasulitan
 <!-- {{SOURCES_LIST}} -->
 <!-- @ OPTIONAL @ -->
 <!-- A list of sentence sources, can be curated to the top-N -->
-錄音文本取自《十二年國教原住民族語文教材》第一至九階課文之族語（羅馬字）內容，經[中華民國教育部國民及學前教育署](https://www.k12ea.gov.tw)（K-12 Education Administration, Ministry of Education, Taiwan ROC）授權，由台灣維基媒體協會整理後上傳。特別感謝時任教育部政務次長葉丙成協助協調授權事宜。
+The recording texts are taken from the Indigenous Languages Curriculum (K-12) textbook content (in romanization) for levels 1 to 9, uploaded by Wikimedia Taiwan under authorization from the K-12 Education Administration, Ministry of Education (Taiwan, ROC): https://www.k12ea.gov.tw. Special thanks to Deputy Minister Ping-Cheng Yeh for facilitating the authorization.
 
-少部分錄音文本由國⽴台灣⼤學語⾔學研究所《[台⼤台灣南島語語料庫](https://corpus.linguistics.ntu.edu.tw/)》（NTU Corpus of Formosan Languages, Graduate Institute of Linguistics, National Taiwan University）提供。感謝宋麗梅老師協助。
+A small portion of the texts is provided by the NTU Corpus of Formosan Languages (Graduate Institute of Linguistics, National Taiwan University): https://corpus.linguistics.ntu.edu.tw/ (thanks to Prof. Li-May Sung for assistance).
 
-在族語專案錄音過程中，我們發現部分文本存在文意不符、單詞或拼寫錯誤等情況。因 Common Voice 系統限制，相關內容未能事先更正仍直接進行錄製。錄音者與教材之間是為共同協作關係，特此說明。
+During the recording project, we noticed certain semantic mismatches and typographical/spelling issues in parts of the text. Due to Common Voice system constraints, these were not corrected in advance and recordings proceeded as-is. Recorders and textbook providers collaborated closely; this note is provided for transparency.
 
 ### Text domains
 | Domain | Count |
@@ -153,17 +153,17 @@ information.
 ## Get involved!
 
 ### Community links
-Mozilla 台灣社群 (MozTW) Common Voice 專案網站： [https://moztw.org/commonvoice/](https://moztw.org/commonvoice/)
+MozTW (Mozilla Taiwan) Common Voice project site: https://moztw.org/commonvoice/
 
-任何問題與建議、協助推廣、捐贈語料，或其他合作需求，請透過以下社群頻道與我們討論：
+For questions, suggestions, outreach, donating text, or collaboration, please reach out via:
 
-- [Telegram group](https://t.me/+gvmHEcAtd-IwNzFl)
-- [Line group](https://line.me/ti/g/_PLyjCSe_8)
+- Telegram group: https://t.me/+gvmHEcAtd-IwNzFl
+- Line group: https://line.me/ti/g/_PLyjCSe_8
 
-2025 族語錄音計畫參與社群：
+Communities involved in the 2025 Indigenous language recording project:
 
-- [台灣維基媒體協會 (Wikimedia Taiwan)](https://www.facebook.com/wikimedia.tw)
-- 花蓮縣撒奇萊雅族維基媒體協會
+- Wikimedia Taiwan: https://www.facebook.com/wikimedia.tw
+- Hualien County Sakizaya Wikimedia Association
 <!-- {{COMMUNITY_LINKS_LIST}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Links to community chats / fora -->
@@ -172,8 +172,8 @@ Mozilla 台灣社群 (MozTW) Common Voice 專案網站： [https://moztw.org/com
 <!-- {{DISCUSSION_LINKS_LIST}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Any links to discussions, for example on Discourse or other fora or blogs can be included here -->
-* [Discourse 討論區](https://discourse.mozilla.org/c/voice/zh-tw/286)
-* [相關新聞](https://hackmd.io/@moztw/common-voice-news)
+* Discourse forum (zh-TW): https://discourse.mozilla.org/c/voice/zh-tw/286
+* Related news: https://hackmd.io/@moztw/common-voice-news
 
 ### Contribute
 * [Speak](https://commonvoice.mozilla.org/szy/speak)
@@ -186,7 +186,7 @@ Mozilla 台灣社群 (MozTW) Common Voice 專案網站： [https://moztw.org/com
 ### Datasheet authors
 <!-- {{DATASHEET_AUTHORS_LIST}} -->
 <!-- A list in the format of: Your Name <email@email.com> -->
- - Irvin Chen (MozTW 社群聯絡人) <irvin@moztw.org>
+ - Irvin Chen (MozTW Community Contact) <irvin@moztw.org>
 
 ### Citation guidelines
 <!-- {{CITATION_DESCRIPTION}} -->

--- a/cv-corpus/scs/23.0-2025-09-05/final/en/tay.md
+++ b/cv-corpus/scs/23.0-2025-09-05/final/en/tay.md
@@ -5,25 +5,25 @@
 for Atayal (`tay`). The dataset contains 7857 clips representing 13 hours of recorded
 speech (12 hours validated) from 18 speakers.
 
-本語料集包含泰雅族語推組織的 18 位錄音者，錄音範圍為十二年國教課程原住民族語文教材第 1 至 9 階課文文本。
+This dataset includes 18 speakers from Atayal language promotion organizations. The recordings cover the Indigenous Languages Curriculum (K-12) textbook materials, level 1 to 9.
 
 ## Language
 <!-- {{LANGUAGE_DESCRIPTION}} -->
 <!-- Provide a brief (1-2 paragraph) description of your language -->
-泰雅語（Atayal / Tayal），臺灣原住民泰雅族的語言
+Atayal (Tayal) is the language of the Atayal people, an Indigenous people of Taiwan.
 
 ### Variants
 <!-- {{VARIANT_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Describe the variants (MCV variants) of your language -->
-本語音語料庫包含以下方言語群
+This speech corpus includes the following dialect groups:
 
-- 賽考利克泰雅語 Squliq Atayal (`squliq`)
-- 澤敖利泰雅語 Sʼuli Atayal (`ciuli`)
-- 宜蘭澤敖利泰雅語 Klesan Atayal (`klesan`)
-- 四季泰雅語 Skikun Atayal (`cquliq`)
-- 汶水泰雅語 Matuʼuwal Atayal (`matuuwal`)
-- 萬大泰雅語 Plngawan Atayal (`pingawan`)
+- Squliq Atayal (`squliq`)
+- Sʼuli Atayal (`ciuli`)
+- Klesan Atayal (`klesan`)
+- Skikun Atayal (`cquliq`)
+- Matuʼuwal Atayal (`matuuwal`)
+- Plngawan Atayal (`pingawan`)
 
 ## Demographic information
 The dataset includes the following distribution of age and gender.
@@ -32,7 +32,7 @@ The dataset includes the following distribution of age and gender.
 ### Gender
 Self-declared gender information, percentage refers to the number of clips annotated with this gender.
 
-（2025 年初 MozTW / 台灣維基協會族語錄音專案，並未登錄此資訊，故此資料相對不準確。）
+(The MozTW / Wikimedia Taiwan Indigenous language recording project in early 2025 did not collect this information; therefore, these figures may be relatively inaccurate.)
 
 | Gender | Pertentage |
 |-|-|
@@ -50,7 +50,7 @@ Self-declared gender information, percentage refers to the number of clips annot
 ### Age
 Self-declared age information, percentage refers to the number of clips annotated with this age band.
 
-（2025 年初 MozTW / 台灣維基協會族語錄音專案，並未登錄此資訊，故此資料相對不準確。）
+(The MozTW / Wikimedia Taiwan Indigenous language recording project in early 2025 did not collect this information; therefore, these figures may be relatively inaccurate.)
 
 | Age Band | Percentage |
 |-|-|
@@ -111,11 +111,11 @@ bali nanak ku’ muwani iwana makibaq ’i’ matiq
 <!-- {{SOURCES_LIST}} -->
 <!-- @ OPTIONAL @ -->
 <!-- A list of sentence sources, can be curated to the top-N -->
-錄音文本取自《十二年國教原住民族語文教材》第一至九階課文之族語（羅馬字）內容，經[中華民國教育部國民及學前教育署](https://www.k12ea.gov.tw)（K-12 Education Administration, Ministry of Education, Taiwan ROC）授權，由台灣維基媒體協會整理後上傳。特別感謝時任教育部政務次長葉丙成協助協調授權事宜。
+The recording texts are taken from the Indigenous Languages Curriculum (K-12) textbook content (in romanization) for levels 1 to 9, uploaded by Wikimedia Taiwan under authorization from the K-12 Education Administration, Ministry of Education (Taiwan, ROC): https://www.k12ea.gov.tw. Special thanks to Deputy Minister Ping-Cheng Yeh for facilitating the authorization.
 
-賽考利克泰雅語另包含[泰雅爾語聖經](https://cb.fhl.net)選句共 115 句，感謝財團法人台灣聖經公會（The Bible Society in Taiwan）授權。
+For Squliq Atayal, 115 selected verses from the Tayal Bible (see https://cb.fhl.net) are included, with authorization from The Bible Society in Taiwan.
 
-在族語專案錄音過程中，我們發現部分文本存在文意不符、單詞或拼寫錯誤等情況。因 Common Voice 系統限制，相關內容未能事先更正仍直接進行錄製。錄音者與教材之間是為共同協作關係，特此說明。
+During the recording project, we noticed certain semantic mismatches and typographical/spelling issues in parts of the text. Due to Common Voice system constraints, these were not corrected in advance and recordings proceeded as-is. Recorders and textbook providers collaborated closely; this note is provided for transparency.
 
 ### Text domains
 | Domain | Count |
@@ -159,18 +159,18 @@ information.
 ## Get involved!
 
 ### Community links
-Mozilla 台灣社群 (MozTW) Common Voice 專案網站： [https://moztw.org/commonvoice/](https://moztw.org/commonvoice/)
+MozTW (Mozilla Taiwan) Common Voice project site: https://moztw.org/commonvoice/
 
-任何問題與建議、協助推廣、捐贈語料，或其他合作需求，請透過以下社群頻道與我們討論：
+For questions, suggestions, outreach, donating text, or collaboration, please reach out via:
 
-- [Telegram group](https://t.me/+gvmHEcAtd-IwNzFl)
-- [Line group](https://line.me/ti/g/_PLyjCSe_8)
+- Telegram group: https://t.me/+gvmHEcAtd-IwNzFl
+- Line group: https://line.me/ti/g/_PLyjCSe_8
 
-2025 族語錄音計畫參與社群：
+Communities involved in the 2025 Indigenous language recording project:
 
-- [台灣維基媒體協會 (Wikimedia Taiwan)](https://www.facebook.com/wikimedia.tw)
-- [泰雅族語言推廣組織](https://www.kenatayal.org.tw)、[泰雅族語推動組織 Facebook](https://www.facebook.com/p/%E6%B3%B0%E9%9B%85%E6%97%8F%E8%AA%9E%E6%8E%A8%E5%8B%95%E7%B5%84%E7%B9%94-100064743246737/)
-- 特別感謝泰雅語推組織 Sugiy‧Tosi 素伊‧多夕老師協助
+- Wikimedia Taiwan: https://www.facebook.com/wikimedia.tw
+- Atayal language promotion organizations: https://www.kenatayal.org.tw and https://www.facebook.com/p/%E6%B3%B0%E9%9B%85%E6%97%8F%E8%AA%9E%E6%8E%A8%E5%8B%95%E7%B5%84%E7%B9%94-100064743246737/
+- Special thanks to teacher Sugiy‧Tosi for assistance
 <!-- {{COMMUNITY_LINKS_LIST}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Links to community chats / fora -->
@@ -179,8 +179,8 @@ Mozilla 台灣社群 (MozTW) Common Voice 專案網站： [https://moztw.org/com
 <!-- {{DISCUSSION_LINKS_LIST}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Any links to discussions, for example on Discourse or other fora or blogs can be included here -->
-* [Discourse 討論區](https://discourse.mozilla.org/c/voice/zh-tw/286)
-* [相關新聞](https://hackmd.io/@moztw/common-voice-news)
+* Discourse forum (zh-TW): https://discourse.mozilla.org/c/voice/zh-tw/286
+* Related news: https://hackmd.io/@moztw/common-voice-news
 
 ### Contribute
 * [Speak](https://commonvoice.mozilla.org/tay/speak)
@@ -193,7 +193,7 @@ Mozilla 台灣社群 (MozTW) Common Voice 專案網站： [https://moztw.org/com
 ### Datasheet authors
 <!-- {{DATASHEET_AUTHORS_LIST}} -->
 <!-- A list in the format of: Your Name <email@email.com> -->
- - Irvin Chen (MozTW 社群聯絡人) <irvin@moztw.org>
+ - Irvin Chen (MozTW Community Contact) <irvin@moztw.org>
 
 ### Citation guidelines
 <!-- {{CITATION_DESCRIPTION}} -->

--- a/cv-corpus/scs/23.0-2025-09-05/final/en/trv.md
+++ b/cv-corpus/scs/23.0-2025-09-05/final/en/trv.md
@@ -5,22 +5,22 @@
 for Seediq (`trv`). The dataset contains 6490 clips representing 11 hours of recorded
 speech (10 hours validated) from 10 speakers.
 
-本語料集包含來自賽德克族語言推動組織的 10 位錄音者，錄音範圍為十二年國教課程原住民族語文教材第 1 至 9 階課文文本。
+This dataset includes 10 speakers from Seediq language promotion organizations. The recordings cover the Indigenous Languages Curriculum (K-12) textbook materials, level 1 to 9.
 
 ## Language
 <!-- {{LANGUAGE_DESCRIPTION}} -->
 <!-- Provide a brief (1-2 paragraph) description of your language -->
-賽德克語（Seediq），臺灣原住民賽德克族的語言
+Seediq is the language of the Seediq people, an Indigenous people of Taiwan.
 
 ### Variants
 <!-- {{VARIANT_DESCRIPTION}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Describe the variants (MCV variants) of your language -->
-本語音語料庫包含以下方言語群
+This speech corpus includes the following dialect groups:
 
-- 德固達雅賽德克語 Tgdaya Seediq (`tgdaya`)
-- 都達賽德克語 Toda Sediq (`toda`)
-- 德鹿谷賽德克語 Truku Seejiq (`truku`)
+- Tgdaya Seediq (`tgdaya`)
+- Toda Sediq (`toda`)
+- Truku Seejiq (`truku`)
 
 ## Demographic information
 The dataset includes the following distribution of age and gender.
@@ -29,7 +29,7 @@ The dataset includes the following distribution of age and gender.
 ### Gender
 Self-declared gender information, percentage refers to the number of clips annotated with this gender.
 
-（2025 年初 MozTW / 台灣維基協會族語錄音專案，並未登錄此資訊，故此資料相對不準確。）
+(The MozTW / Wikimedia Taiwan Indigenous language recording project in early 2025 did not collect this information; therefore, these figures may be relatively inaccurate.)
 
 | Gender | Pertentage |
 |-|-|
@@ -48,7 +48,7 @@ Self-declared gender information, percentage refers to the number of clips annot
 ### Age
 Self-declared age information, percentage refers to the number of clips annotated with this age band.
 
-（2025 年初 MozTW / 台灣維基協會族語錄音專案，並未登錄此資訊，故此資料相對不準確。）
+(The MozTW / Wikimedia Taiwan Indigenous language recording project in early 2025 did not collect this information; therefore, these figures may be relatively inaccurate.)
 
 | Age Band | Percentage |
 |-|-|
@@ -106,13 +106,13 @@ Iya bay tuting durang kadi probo ha!
 <!-- {{SOURCES_LIST}} -->
 <!-- @ OPTIONAL @ -->
 <!-- A list of sentence sources, can be curated to the top-N -->
-錄音文本取自《十二年國教原住民族語文教材》第一至九階課文之族語（羅馬字）內容，經[中華民國教育部國民及學前教育署](https://www.k12ea.gov.tw)（K-12 Education Administration, Ministry of Education, Taiwan ROC）授權，由台灣維基媒體協會整理後上傳。特別感謝時任教育部政務次長葉丙成協助協調授權事宜。
+The recording texts are taken from the Indigenous Languages Curriculum (K-12) textbook content (in romanization) for levels 1 to 9, uploaded by Wikimedia Taiwan under authorization from the K-12 Education Administration, Ministry of Education (Taiwan, ROC): https://www.k12ea.gov.tw. Special thanks to Deputy Minister Ping-Cheng Yeh for facilitating the authorization.
 
-德固達雅賽德克語另包含[賽德克族Tgdaya語聖經](https://cb.fhl.net)選句共 119 句，感謝財團法人台灣聖經公會（The Bible Society in Taiwan）授權。
+For Tgdaya Seediq, 119 selected verses from the Seediq Tgdaya Bible (see https://cb.fhl.net) are included, with authorization from The Bible Society in Taiwan.
 
-少部分德固達雅賽德克語（`tgdaya`）文本，由國⽴台灣⼤學語⾔學研究所《[台⼤台灣南島語語料庫](https://corpus.linguistics.ntu.edu.tw/)》（NTU Corpus of Formosan Languages, Graduate Institute of Linguistics, National Taiwan University）提供。感謝宋麗梅老師協助。
+A portion of the Tgdaya (`tgdaya`) texts is provided by the NTU Corpus of Formosan Languages (Graduate Institute of Linguistics, National Taiwan University): https://corpus.linguistics.ntu.edu.tw/ (thanks to Prof. Li-May Sung for assistance).
 
-在族語專案錄音過程中，我們發現部分文本存在文意不符、單詞或拼寫錯誤等情況。因 Common Voice 系統限制，相關內容未能事先更正仍直接進行錄製。錄音者與教材之間是為共同協作關係，特此說明。
+During the recording project, we noticed certain semantic mismatches and typographical/spelling issues in parts of the text. Due to Common Voice system constraints, these were not corrected in advance and recordings proceeded as-is. Recorders and textbook providers collaborated closely; this note is provided for transparency.
 
 ### Text domains
 | Domain | Count |
@@ -156,17 +156,17 @@ information.
 ## Get involved!
 
 ### Community links
-Mozilla 台灣社群 (MozTW) Common Voice 專案網站： [https://moztw.org/commonvoice/](https://moztw.org/commonvoice/)
+MozTW (Mozilla Taiwan) Common Voice project site: https://moztw.org/commonvoice/
 
-任何問題與建議、協助推廣、捐贈語料，或其他合作需求，請透過以下社群頻道與我們討論：
+For questions, suggestions, outreach, donating text, or collaboration, please reach out via:
 
-- [Telegram group](https://t.me/+gvmHEcAtd-IwNzFl)
-- [Line group](https://line.me/ti/g/_PLyjCSe_8)
+- Telegram group: https://t.me/+gvmHEcAtd-IwNzFl
+- Line group: https://line.me/ti/g/_PLyjCSe_8
 
-2025 族語錄音計畫參與社群：
+Communities involved in the 2025 Indigenous language recording project:
 
-- [賽德克族語言推動組織](https://www.facebook.com/Kari3s4t/)
-- 特別感謝林江苹秀 Bilaq Watan 協助招募與錄音事宜
+- Seediq language promotion organizations: https://www.facebook.com/Kari3s4t/
+- Special thanks to Bilaq Watan for recruitment and recording support
 <!-- {{COMMUNITY_LINKS_LIST}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Links to community chats / fora -->
@@ -175,8 +175,8 @@ Mozilla 台灣社群 (MozTW) Common Voice 專案網站： [https://moztw.org/com
 <!-- {{DISCUSSION_LINKS_LIST}} -->
 <!-- @ OPTIONAL @ -->
 <!-- Any links to discussions, for example on Discourse or other fora or blogs can be included here -->
-* [Discourse 討論區](https://discourse.mozilla.org/c/voice/zh-tw/286)
-* [相關新聞](https://hackmd.io/@moztw/common-voice-news)
+* Discourse forum (zh-TW): https://discourse.mozilla.org/c/voice/zh-tw/286
+* Related news: https://hackmd.io/@moztw/common-voice-news
 
 ### Contribute
 * [Speak](https://commonvoice.mozilla.org/trv/speak)
@@ -189,7 +189,7 @@ Mozilla 台灣社群 (MozTW) Common Voice 專案網站： [https://moztw.org/com
 ### Datasheet authors
 <!-- {{DATASHEET_AUTHORS_LIST}} -->
 <!-- A list in the format of: Your Name <email@email.com> -->
- - Irvin Chen (MozTW 社群聯絡人) <irvin@moztw.org>
+ - Irvin Chen (MozTW Community Contact) <irvin@moztw.org>
 
 ### Citation guidelines
 <!-- {{CITATION_DESCRIPTION}} -->

--- a/cv-corpus/scs/23.0-2025-09-05/final/en/zh-TW.md
+++ b/cv-corpus/scs/23.0-2025-09-05/final/en/zh-TW.md
@@ -8,7 +8,7 @@ speech (77 hours validated) from 2291 speakers.
 ## Language
 <!-- {{LANGUAGE_DESCRIPTION}} -->
 <!-- Provide a brief (1-2 paragraph) description of your language -->
-中華民國國語（台灣華語），繁體中文語料文字。
+Taiwan Mandarin in Traditional Chinese script.
 
 ### Variants
 <!-- {{VARIANT_DESCRIPTION}} -->
@@ -70,15 +70,15 @@ The text corpus contains `21589` sentences, of which `20748` are validated, `841
 <!-- @ OPTIONAL @ -->
 <!-- An overview of the text corpus, with information such as average length (in characters and words) of validated sentences. -->
 
-大部分繁體文本語料整理於：[MozTW CC0 語料庫](https://github.com/moztw/cc0-sentences)。
+Most of the Traditional Chinese text corpus is curated in the MozTW CC0 Sentences repository: https://github.com/moztw/cc0-sentences.
 
-以下是文本語料的統計資訊，請檢視上述 repo 以進一步瞭解統計方式：
+Summary statistics (see the repo for methods):
 
-> There are 3573 characters in the corpus, covering about 85.6% of the MOU 2015 common chars data (教育部2015常用字99.75% (3593字)).
-> 
-> 1046 phonetic are covered, about 66.75% of the total phonetic from CnsPhonetic2016-08v2.cin table.
+> There are 3573 characters in the corpus, covering about 85.6% of the MOU 2015 common chars data (MoE 2015 common characters 99.75% (3593 chars)).
+>
+> 1046 phonetics are covered, about 66.75% of the total phonetics in CnsPhonetic2016-08v2.cin.
 
-我們亟需更多「日常生活用句」，歡迎捐贈您以國語書寫的作品，請參考下方社群頻道資訊與我們聯繫。
+We welcome more everyday sentences in Mandarin (Traditional Chinese). Please reach out via the community links below.
 
 ### Writing system
 <!-- {{WRITING_SYSTEM_DESCRIPTION}} -->
@@ -107,7 +107,7 @@ There follows a randomly selected sample of five sentences from the corpus.
 <!-- @ OPTIONAL @ -->
 <!-- A list of sentence sources, can be curated to the top-N -->
 
-文本語料由 Mozilla 台灣社群、g0v 社群、及其他開放原始碼運動參與者共同建立。
+The text corpus is built by the Mozilla Taiwan community, the g0v community, and other open-source contributors.
 
 ### Text domains
 | Domain | Count |
@@ -179,13 +179,13 @@ Mozilla 台灣社群 (MozTW) Common Voice 專案網站： [https://moztw.org/com
 <!-- @ OPTIONAL @ -->
 <!-- Any links to discussions, for example on Discourse or other fora or blogs can be included here -->
 
-* [Discourse 討論區](https://discourse.mozilla.org/c/voice/zh-tw/286)
-* [相關新聞](https://hackmd.io/@moztw/common-voice-news)
+* Discourse forum (zh-TW): https://discourse.mozilla.org/c/voice/zh-tw/286
+* Related news: https://hackmd.io/@moztw/common-voice-news
 
 ### Contribute
 * [Speak](https://commonvoice.mozilla.org/zh-TW/speak)
 * [Listen](https://commonvoice.mozilla.org/zh-TW/listen)
-* 捐出你的句子 - 如您有意願捐出你擁有的文本語料（例如您的個人創作）供參與者錄音，請先聯絡 Irvin （ irvin@moztw.org ）或於以上 Line / Telegram 群組討論。
+* Donate your sentences — If you would like to donate text you own (e.g., original writing) for recording, please contact Irvin (irvin@moztw.org) or discuss in the Line/Telegram groups above.
 
 <!-- {{CONTRIBUTE_LINKS_LIST}} -->
 <!-- Here you can include links for how to contribute to the dataset -->
@@ -196,7 +196,7 @@ Mozilla 台灣社群 (MozTW) Common Voice 專案網站： [https://moztw.org/com
 <!-- {{DATASHEET_AUTHORS_LIST}} -->
 <!-- A list in the format of: Your Name <email@email.com> -->
 
-- Irvin Chen (MozTW 社群聯絡人) <irvin@moztw.org>
+- Irvin Chen (MozTW Community Contact) <irvin@moztw.org>
 
 ### Citation guidelines
 <!-- {{CITATION_DESCRIPTION}} -->


### PR DESCRIPTION
Hi, we want to provide the interim English version of the datasheets to honor the participants and corpus providers, and provide the necessary info such as dialect and post-processing suggestions, before the [localization version](https://github.com/common-voice/cv-datasheets/tree/main/cv-corpus/scs/23.0-2025-09-05/final/zh-TW) to be able to publish on the datacollective sites.
