### PR TITLE
1556-Add preview and auto compile workflow

### DIFF
--- a/.github/workflows/compile-latest.yml
+++ b/.github/workflows/compile-latest.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: compile-latest
+  cancel-in-progress: true
+
 jobs:
   compile:
     runs-on: ubuntu-latest

--- a/.github/workflows/compile-latest.yml
+++ b/.github/workflows/compile-latest.yml
@@ -1,0 +1,71 @@
+name: Compile datasheets-latest.json
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "content/**"
+      - "templates/**"
+      - "metadata/**"
+      - "compile_datasheets.py"
+      - "scripts/fetch_api_metadata.py"
+
+permissions:
+  contents: write
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+
+    # Skip if this push was the auto-compile commit itself
+    if: "!contains(github.event.head_commit.message, 'chore: auto-compile')"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install jinja2
+
+      - name: Find latest API snapshot
+        id: snapshot
+        run: |
+          snapshot=$(ls -1 metadata/api-snapshots/languagedata-*.json | sort | tail -1)
+          if [ -z "$snapshot" ]; then
+            echo "No API snapshot found"
+            exit 1
+          fi
+          echo "path=${snapshot}" >> "$GITHUB_OUTPUT"
+          echo "Using snapshot: ${snapshot}"
+
+      - name: Compile datasheets-latest.json
+        run: |
+          python compile_datasheets.py latest \
+            --api-snapshot "${{ steps.snapshot.outputs.path }}" \
+            --output releases/datasheets-latest.json \
+            --pretty
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if git diff --quiet releases/datasheets-latest.json 2>/dev/null; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No changes in datasheets-latest.json"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "datasheets-latest.json has changes"
+          fi
+
+      - name: Commit and push
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add releases/datasheets-latest.json
+          git commit -m "chore: auto-compile datasheets-latest.json"
+          git push

--- a/.github/workflows/compile-latest.yml
+++ b/.github/workflows/compile-latest.yml
@@ -57,12 +57,12 @@ jobs:
       - name: Check for changes
         id: diff
         run: |
-          if git diff --quiet releases/datasheets-latest.json 2>/dev/null; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "No changes in datasheets-latest.json"
-          else
+          if [ -n "$(git status --porcelain releases/datasheets-latest.json)" ]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
             echo "datasheets-latest.json has changes"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No changes in datasheets-latest.json"
           fi
 
       - name: Commit and push

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,148 @@
+name: Datasheet Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "content/**"
+      - "templates/**"
+      - "metadata/**"
+      - "compile_datasheets.py"
+      - "scripts/preview_datasheets.py"
+
+  workflow_dispatch:
+    inputs:
+      locales:
+        description: "Locale codes to preview (space-separated, e.g. 'ady kbd es'). Leave empty to auto-detect from PR."
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # needed for git diff against main
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install jinja2
+
+      - name: Determine locales to preview
+        id: locales
+        run: |
+          if [ -n "${{ github.event.inputs.locales }}" ]; then
+            echo "args=-l ${{ github.event.inputs.locales }}" >> "$GITHUB_OUTPUT"
+            echo "Previewing manually specified locales: ${{ github.event.inputs.locales }}"
+          else
+            echo "args=--changed" >> "$GITHUB_OUTPUT"
+            echo "Auto-detecting changed locales from diff"
+          fi
+
+      - name: Generate previews
+        id: generate
+        run: |
+          python scripts/preview_datasheets.py ${{ steps.locales.outputs.args }} 2>&1 | tee /tmp/preview-log.txt
+          # Collect generated preview files
+          if ls previews/preview-*.md 1>/dev/null 2>&1; then
+            echo "has_previews=true" >> "$GITHUB_OUTPUT"
+            echo "Generated previews:"
+            ls -la previews/preview-*.md
+          else
+            echo "has_previews=false" >> "$GITHUB_OUTPUT"
+            echo "No previews generated"
+          fi
+
+      - name: Build PR comment
+        if: steps.generate.outputs.has_previews == 'true' && github.event_name == 'pull_request'
+        id: comment
+        run: |
+          # Build markdown comment body from preview files
+          {
+            echo "## Datasheet Preview"
+            echo ""
+
+            count=$(ls previews/preview-*.md 2>/dev/null | wc -l)
+            echo "Preview for **${count} datasheet(s)** in this PR."
+            echo ""
+
+            for f in previews/preview-*.md; do
+              # Extract locale and modality from filename: preview-{locale}-{modality}.md
+              basename=$(basename "$f" .md)
+              locale=$(echo "$basename" | sed 's/^preview-//; s/-[^-]*$//')
+              modality=$(echo "$basename" | sed 's/.*-//' | tr '[:lower:]' '[:upper:]')
+
+              # Read the preview content
+              content=$(cat "$f")
+
+              # Truncate if too long (keep under 5000 chars per preview)
+              if [ ${#content} -gt 5000 ]; then
+                content="${content:0:5000}
+
+          ...
+
+          *(truncated - full preview available as workflow artifact)*"
+              fi
+
+              echo "<details>"
+              echo "<summary><strong>${locale}</strong> (${modality})</summary>"
+              echo ""
+              echo "${content}"
+              echo ""
+              echo "</details>"
+              echo ""
+            done
+
+            echo "---"
+            echo ""
+            echo "> This preview uses dummy statistics (marked with \`?\`). Actual numbers are filled by the bundler at release time."
+          } > /tmp/pr-comment.md
+
+          # Check total size (GitHub comment limit: 65536 chars)
+          size=$(wc -c < /tmp/pr-comment.md)
+          echo "Comment size: ${size} bytes"
+          if [ "$size" -gt 60000 ]; then
+            {
+              echo "## Datasheet Preview"
+              echo ""
+              echo "Preview generated for **${count} datasheet(s)** but the comment would be too large."
+              echo "Download the preview files from the workflow artifacts."
+            } > /tmp/pr-comment.md
+          fi
+
+      - name: Find existing comment
+        if: steps.generate.outputs.has_previews == 'true' && github.event_name == 'pull_request'
+        uses: peter-evans/find-comment@v3
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "## Datasheet Preview"
+
+      - name: Post or update PR comment
+        if: steps.generate.outputs.has_previews == 'true' && github.event_name == 'pull_request'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: /tmp/pr-comment.md
+          edit-mode: replace
+
+      - name: Upload preview artifacts
+        if: steps.generate.outputs.has_previews == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: datasheet-previews
+          path: previews/preview-*.md
+          retention-days: 5

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -41,7 +41,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install jinja2
+        run: pip install jinja2 pymarkdownlnt
 
       - name: Determine locales to preview
         id: locales
@@ -77,49 +77,96 @@ jobs:
             echo "No previews generated"
           fi
 
+      - name: Lint previews
+        if: steps.generate.outputs.has_previews == 'true'
+        run: |
+          RULES_URL="https://github.com/jackdewinter/pymarkdown/blob/main/docs/rules"
+
+          # Lint and filter out template-generated noise (line-length, inline HTML, emphasis-as-heading, first-line)
+          pymarkdown scan previews/preview-*.md 2>&1 \
+            | grep -v "MD013\|MD033\|MD036\|MD041" \
+            > /tmp/lint-raw.txt || true
+
+          # Enrich lint output with line content and rule doc links
+          > /tmp/lint-output.txt
+          while IFS= read -r line; do
+            file=$(echo "$line" | cut -d: -f1)
+            lineno=$(echo "$line" | cut -d: -f2)
+            rest=$(echo "$line" | cut -d: -f3-)
+            # Extract rule ID (e.g. MD009)
+            rule=$(echo "$rest" | grep -oP 'MD\d+' | head -1)
+            rule_lower=$(echo "$rule" | tr '[:upper:]' '[:lower:]')
+            if [ -f "$file" ] && [ -n "$lineno" ]; then
+              src=$(sed -n "${lineno}p" "$file" 2>/dev/null | head -c 120)
+              short_file=$(basename "$file" .md)
+              if [ -n "$rule" ]; then
+                echo "- **${short_file}** -${rest} ([${rule}](${RULES_URL}/${rule_lower}.md))" >> /tmp/lint-output.txt
+              else
+                echo "- **${short_file}** -${rest}" >> /tmp/lint-output.txt
+              fi
+              if [ -n "$src" ]; then
+                echo "  \`${src}\`" >> /tmp/lint-output.txt
+              fi
+            fi
+          done < /tmp/lint-raw.txt
+
+          if [ -s /tmp/lint-output.txt ]; then
+            echo "Lint issues found:"
+            cat /tmp/lint-output.txt
+          else
+            echo "No lint issues"
+          fi
+
       - name: Build PR comment
         if: steps.generate.outputs.has_previews == 'true' && github.event_name == 'pull_request'
         id: comment
         run: |
-          # Build markdown comment body from preview files
+          count=$(ls previews/preview-*.md 2>/dev/null | wc -l)
+
+          # Build markdown comment body
           {
             echo "## Datasheet Preview"
             echo ""
-
-            count=$(ls previews/preview-*.md 2>/dev/null | wc -l)
+            echo "> **Preview with dummy data** - Statistics marked with \`?\` are placeholders. Actual numbers are filled by the bundler at release time. Full preview files are available as downloadable artifacts in this workflow run."
+            echo ""
             echo "Preview for **${count} datasheet(s)** in this PR."
             echo ""
 
-            for f in previews/preview-*.md; do
-              # Extract locale and modality from filename: preview-{locale}-{modality}.md
+            # Include lint issues if any
+            if [ -s /tmp/lint-output.txt ]; then
+              echo "<details>"
+              echo "<summary><strong>Markdown lint issues</strong></summary>"
+              echo ""
+              cat /tmp/lint-output.txt
+              echo ""
+              echo "</details>"
+              echo ""
+            fi
+
+            echo "---"
+            echo ""
+
+            files=(previews/preview-*.md)
+            last_idx=$(( ${#files[@]} - 1 ))
+            for i in "${!files[@]}"; do
+              f="${files[$i]}"
               basename=$(basename "$f" .md)
               locale=$(echo "$basename" | sed 's/^preview-//; s/-[^-]*$//')
               modality=$(echo "$basename" | sed 's/.*-//' | tr '[:lower:]' '[:upper:]')
 
-              # Read the preview content
-              content=$(cat "$f")
-
-              # Truncate if too long (keep under 5000 chars per preview)
-              if [ ${#content} -gt 5000 ]; then
-                content="${content:0:5000}
-
-          ...
-
-          *(truncated - full preview available as workflow artifact)*"
-              fi
-
               echo "<details>"
               echo "<summary><strong>${locale}</strong> (${modality})</summary>"
               echo ""
-              echo "${content}"
+              cat "$f"
               echo ""
               echo "</details>"
               echo ""
+              # Add divider between previews, but not after the last one
+              if [ "$i" -lt "$last_idx" ]; then
+                echo "---"
+                echo ""
+              fi
             done
-
-            echo "---"
-            echo ""
-            echo "> This preview uses dummy statistics (marked with \`?\`). Actual numbers are filled by the bundler at release time."
           } > /tmp/pr-comment.md
 
           # Check total size (GitHub comment limit: 65536 chars)
@@ -129,8 +176,10 @@ jobs:
             {
               echo "## Datasheet Preview"
               echo ""
-              echo "Preview generated for **${count} datasheet(s)** but the comment would be too large."
-              echo "Download the preview files from the workflow artifacts."
+              echo "> **Preview with dummy data** - Statistics marked with \`?\` are placeholders."
+              echo ""
+              echo "Preview generated for **${count} datasheet(s)** but the comment is too large to display inline."
+              echo "Download the full preview files from the **Artifacts** section of this workflow run."
             } > /tmp/pr-comment.md
           fi
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -21,6 +21,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: preview-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   preview:
     runs-on: ubuntu-latest
@@ -41,10 +45,17 @@ jobs:
 
       - name: Determine locales to preview
         id: locales
+        env:
+          INPUT_LOCALES: ${{ github.event.inputs.locales }}
         run: |
-          if [ -n "${{ github.event.inputs.locales }}" ]; then
-            echo "args=-l ${{ github.event.inputs.locales }}" >> "$GITHUB_OUTPUT"
-            echo "Previewing manually specified locales: ${{ github.event.inputs.locales }}"
+          if [ -n "$INPUT_LOCALES" ]; then
+            # Validate: locale codes may only contain a-z, A-Z, 0-9, and hyphens
+            if ! echo "$INPUT_LOCALES" | grep -qP '^[a-zA-Z0-9\- ]+$'; then
+              echo "Error: Invalid locale input. Only alphanumeric characters and hyphens allowed."
+              exit 1
+            fi
+            echo "args=-l $INPUT_LOCALES" >> "$GITHUB_OUTPUT"
+            echo "Previewing manually specified locales: $INPUT_LOCALES"
           else
             echo "args=--changed" >> "$GITHUB_OUTPUT"
             echo "Auto-detecting changed locales from diff"
@@ -52,8 +63,10 @@ jobs:
 
       - name: Generate previews
         id: generate
+        env:
+          PREVIEW_ARGS: ${{ steps.locales.outputs.args }}
         run: |
-          python scripts/preview_datasheets.py ${{ steps.locales.outputs.args }} 2>&1 | tee /tmp/preview-log.txt
+          python scripts/preview_datasheets.py $PREVIEW_ARGS 2>&1 | tee /tmp/preview-log.txt
           # Collect generated preview files
           if ls previews/preview-*.md 1>/dev/null 2>&1; then
             echo "has_previews=true" >> "$GITHUB_OUTPUT"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Python
+.venv/
+__pycache__/
+*/__pycache__/
+*.egg-info/
+
 # IDEs
 .idea/
 .vscode/
@@ -9,8 +15,3 @@
 # Developer local
 .local/
 .dev/
-
-# Python
-.venv/
-__pycache__/*
-*/__pycache__/*

--- a/README.md
+++ b/README.md
@@ -6,48 +6,47 @@ Datasheets are documents that describe each language dataset in [Common Voice](h
 
 ```mermaid
 flowchart LR
-    SCS_DB[("SCS DB")]
-    SPS_DB[("SPS DB")]
-    GCS_C[("GCS
-    SCS clips")]
-    DS["cv-datasheets ◀"]
-    GCS_A[("GCS
-    SPS audio")]
-    GCS_DS[("GCS
-    datasets
-    datasheets
-    stats")]
-    MDC[["MDC (downloads)"]]
-    CDS[["cv-dataset"]]
 
-    subgraph SCS_B["SCS Bundler"]
+    subgraph SCS["Scripted Speech (SCS)"]
+        SCS_DB[("DB")]
+        SCS_GCS["GCS"]
+    end
+    subgraph SCS_BUN["SCS Bundler"]
         CC["CorporaCreator"]
     end
 
-    subgraph SPS_B["SPS Bundler"]
+    DSH["cv-datasheets ◀"]
+
+    subgraph SPS["Spontaneous Speech (SPS)"]
+        SPS_DB[("DB")]
+        SPS_GCS["GCS"]
+    end
+    subgraph SPS_BUN["SPS Bundler"]
         QA["QA Pipeline"]
     end
 
-    SCS_DB --> SCS_B
-    GCS_C --> SCS_B
-    DS -->|templates
-    + custom| SCS_B
-    DS -->|templates
-    + custom| SPS_B
-    SPS_DB --> SPS_B
-    GCS_A --> SPS_B
-    SCS_B --> GCS_DS
-    SPS_B --> GCS_DS
-    GCS_DS -->|datasets| MDC
-    GCS_DS -->|datasheets| MDC
-    GCS_DS -->|stats| CDS
+    BUN_GCS["GCS
+    datasets
+    datasheets
+    stats"]
 
-    style DS fill:#1a73e8,color:#ffffff,stroke:#1558b0,stroke-width:2px
-    style GCS_C fill:#333,stroke:#383c8e
-    style GCS_A fill:#333,stroke:#383c8e
-    style GCS_DS fill:#333,stroke:#383c8e
-    style CC fill:#333,stroke:#fefefe,stroke-width:1px
-    style QA fill:#333,stroke:#fefefe,stroke-width:1px
+    MDC[["MDC
+    downloads"]]
+    CDS[["cv-dataset"]]
+
+    SCS_DB -->|data| SCS_BUN
+    SCS_GCS -->|clips| SCS_BUN
+    DSH -->|JSON| SCS_BUN
+    DSH -->|JSON| SPS_BUN
+    SPS_DB -->|data| SPS_BUN
+    SPS_GCS -->|audio| SPS_BUN
+    SCS_BUN --> BUN_GCS
+    SPS_BUN --> BUN_GCS
+    BUN_GCS -->|datasets| MDC
+    BUN_GCS -->|datasheets| MDC
+    BUN_GCS -->|stats| CDS
+
+    style DSH fill:#1a73e8,color:#ffffff,stroke:#1558b0,stroke-width:2px
 ```
 
 ## How it works

--- a/README.md
+++ b/README.md
@@ -67,54 +67,22 @@ For details on the compile-time vs runtime split, Jinja2 role, and bundler integ
 
 Language communities are the experts on their languages. We ask community members to contribute datasheet content for their language(s) via Pull Requests.
 
-1. Look at `content/_template/` for the directory structure, file list, and field types
-2. Look at `content/_example/` for a filled-in reference (fictional Klingon locale)
-3. Create or edit files under `content/locales/{your-locale-code}/`
-4. Submit a Pull Request
+> **Please submit one PR per locale** so that previews and reviews stay focused.
 
-Datasheets can also be submitted via Google Forms or email. For the full contributor guide, directory structure, additive vs descriptive field rules, and form links, see [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md).
+For the full contributor guide, directory structure, field rules, and form links, see [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md). Want to have the datasheet in your own language? See [How to Add a Translated Datasheet](docs/CONTRIBUTING.md#how-to-add-a-translated-datasheet).
 
-Want to have the datasheet in your own language? See [How to Add a Translated Datasheet](docs/CONTRIBUTING.md#how-to-add-a-translated-datasheet).
+## Preview
 
-## Repository structure
+Preview how your content will look in the final datasheet: `python3 scripts/preview_datasheets.py -l {locale}`. On Pull Requests, a preview is posted automatically as a comment.
 
-```txt
-cv-datasheets/
-├── templates/                  Jinja2 templates
-│   ├── base.md.j2                Shared skeleton
-│   ├── scripted.md.j2            SCS child template
-│   ├── spontaneous.md.j2         SPS child template
-│   ├── i18n/                     Section title translations (auto-discovered)
-│   └── _legacy/                  Old plain markdown templates (reference)
-│
-├── content/                    Community content
-│   ├── _field_map.json           Field-to-bundler-key mapping
-│   ├── _defaults/                Fallback content per template language
-│   ├── _template/                Empty file structure for contributors
-│   ├── _example/                 Filled-in example (Klingon)
-│   └── locales/{code}/           Per-locale content (shared/, scripted/, spontaneous/)
-│
-├── metadata/                   Static data files
-│   ├── api-snapshots/            Timestamped API snapshots (language names, variants, accents)
-│   ├── locale-extras.json        Locales not in API (el-CY, ms-MY)
-│   ├── template-languages.json   Non-"en" template overrides
-│   └── funding.tsv               OMSF-funded locales
-│
-├── scripts/                    Utilities
-│   ├── fetch_api_metadata.py     Fetch SCS + SPS API -> snapshot
-│   └── extract_community_data.py One-time extraction from legacy datasheets
-│
-├── compile_datasheets.py       Main compile script
-├── schema/                     JSON Schema for output validation
-├── docs/                       Documentation
-│   ├── ARCHITECTURE.md           System design and bundler integration
-│   ├── CONTRIBUTING.md           Community contribution guide
-│   └── COMPILING.md              Compile script usage and release workflow
-│
-├── releases/                   Compiled output (datasheets-{snapshot_date}.json)
-│
-└── _legacy/                    Deprecated scripts, metadata, and generated datasheets
-```
+See [docs/COMPILING.md - Previewing](docs/COMPILING.md#previewing) for details.
+
+## CI/CD
+
+- **Preview** (`preview.yml`) - Auto-generates a preview comment on every PR that touches content, templates, or metadata.
+- **Auto-compile** (`compile-latest.yml`) - On merge to `main`, compiles and commits `releases/datasheets-latest.json`.
+
+See [docs/COMPILING.md - Auto-Compile](docs/COMPILING.md#auto-compile) and [docs/ARCHITECTURE.md - CI/CD](docs/ARCHITECTURE.md#cicd) for details.
 
 ## Quick start
 
@@ -136,3 +104,16 @@ python3 compile_datasheets.py 2026-03-09 \
 ```
 
 For all options and the release workflow, see [docs/COMPILING.md](docs/COMPILING.md).
+
+## Related repositories
+
+| Repository                                                       | Description                                |
+| ---------------------------------------------------------------- | ------------------------------------------ |
+| [common-voice](https://github.com/common-voice/common-voice)     | Scripted Speech (SCS) - main app + bundler |
+| spontaneous-speech (private)                                     | Spontaneous Speech (SPS) - app + bundler   |
+| [cv-dataset](https://github.com/common-voice/cv-dataset)         | Dataset stats collection and releases      |
+| [CorporaCreator](https://github.com/common-voice/CorporaCreator) | Train/dev/test splitting algorithm         |
+
+## Acknowledgements
+
+The PR preview workflow uses [peter-evans/create-or-update-comment](https://github.com/peter-evans/create-or-update-comment) and [peter-evans/find-comment](https://github.com/peter-evans/find-comment) for GitHub Actions PR comments.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,6 +20,52 @@ metadata/ files ──┘                                        │
                                                    README.md -> tar.gz + GCS /datasheets/
 ```
 
+## Repository Structure
+
+```txt
+cv-datasheets/
+├── templates/                  Jinja2 templates
+│   ├── base.md.j2                Shared skeleton
+│   ├── scripted.md.j2            SCS child template
+│   ├── spontaneous.md.j2         SPS child template
+│   ├── i18n/                     Section title translations (auto-discovered)
+│   └── _legacy/                  Old plain markdown templates (reference)
+│
+├── content/                    Community content
+│   ├── _field_map.json           Field-to-bundler-key mapping
+│   ├── _defaults/                Fallback content per template language
+│   ├── _template/                Empty file structure for contributors
+│   ├── _example/                 Filled-in example (Klingon)
+│   └── locales/{code}/           Per-locale content (shared/, scripted/, spontaneous/)
+│
+├── metadata/                   Static data files
+│   ├── api-snapshots/            Timestamped API snapshots (language names, variants, accents)
+│   ├── locale-extras.json        Locales not in API (el-CY, ms-MY)
+│   ├── template-languages.json   Non-"en" template overrides
+│   └── funding.tsv               OMSF-funded locales
+│
+├── scripts/                    Utilities
+│   ├── fetch_api_metadata.py     Fetch SCS + SPS API -> snapshot
+│   ├── preview_datasheets.py     Preview datasheets with dummy stats
+│   └── extract_community_data.py One-time extraction from legacy datasheets
+│
+├── compile_datasheets.py       Main compile script
+├── schema/                     JSON Schema for output validation
+├── docs/                       Documentation
+│   ├── ARCHITECTURE.md           System design and bundler integration
+│   ├── CONTRIBUTING.md           Community contribution guide
+│   └── COMPILING.md              Compile script usage and release workflow
+│
+├── .github/workflows/          CI/CD
+│   ├── preview.yml               PR preview (auto-generates preview comment)
+│   └── compile-latest.yml        Auto-compile datasheets-latest.json on merge
+│
+├── releases/                   Compiled output (datasheets-{snapshot_date}.json)
+├── previews/                   Local preview output (gitignored)
+│
+└── _legacy/                    Deprecated scripts, metadata, and generated datasheets
+```
+
 ## Jinja2 Role
 
 Jinja2 runs **at compile time only** inside this repository. It resolves template inheritance (`base.md.j2` -> child templates) and produces flat markdown strings with `{{KEY}}` markers. The bundler never touches Jinja2.
@@ -172,6 +218,14 @@ It then:
 2. Builds a replacement map from auto-generated stats + community fields + metadata
 3. Replaces `{{KEY}}` placeholders via regex
 4. Writes `README.md` per locale into the dataset tar
+
+## CI/CD
+
+Two GitHub Actions workflows automate the pipeline:
+
+**Preview** (`preview.yml`): Triggers on every PR that touches `content/`, `templates/`, or `metadata/`. Runs `preview_datasheets.py --changed` to compile affected locales from the working tree with dummy statistics, then posts the rendered preview as a comment on the PR. Also detects template-language remappings in `metadata/template-languages.json`.
+
+**Auto-compile** (`compile-latest.yml`): Triggers on push to `main` (after merge). Runs `compile_datasheets.py` with the latest committed API snapshot and commits `releases/datasheets-latest.json` if it changed. The commit message (`chore: auto-compile`) prevents re-triggering.
 
 ## What Goes Where
 

--- a/docs/COMPILING.md
+++ b/docs/COMPILING.md
@@ -96,11 +96,41 @@ Default output: `releases/datasheets-{snapshot_date}.json`
 
 The `--pretty` flag adds indentation for human readability.
 
+## Previewing
+
+Preview how community content will render without needing real bundler statistics:
+
+```bash
+python3 scripts/preview_datasheets.py -l ady          # single locale
+python3 scripts/preview_datasheets.py -l ady kbd es    # multiple locales
+python3 scripts/preview_datasheets.py --changed        # auto-detect from git diff
+```
+
+The preview script:
+
+- Compiles directly from the working tree (no pre-compiled JSON needed)
+- Fetches API metadata on the fly (cached for 24h in `previews/.api-snapshot.json`)
+- Falls back to the latest committed snapshot if the API is unreachable
+- Substitutes `{{KEY}}` placeholders with dummy values (marked `?` in tables)
+- Strips empty sections (same as the bundler)
+- Outputs to `previews/preview-{locale}-{modality}.md` (gitignored)
+
+On Pull Requests, the `preview.yml` workflow runs automatically and posts the rendered preview as a comment.
+
+## Auto-Compile
+
+When changes are merged to `main`, the `compile-latest.yml` workflow automatically recompiles `releases/datasheets-latest.json` using the latest committed API snapshot. This rolling file always reflects the current state of `main`.
+
+The auto-compile triggers on changes to `content/`, `templates/`, `metadata/`, or the compile script itself. The resulting commit (`chore: auto-compile datasheets-latest.json`) does not re-trigger the workflow.
+
 ## Release Workflow
 
 1. Fetch a fresh API snapshot: `python3 scripts/fetch_api_metadata.py`
-2. Update community content via PRs
-3. Compile: `python3 compile_datasheets.py {snapshot_date} --api-snapshot metadata/api-snapshots/languagedata-{YYYYMMDD}.json --pretty`
-4. Review the changelog diff (use `--diff` against previous release)
-5. Commit the release JSON
-6. Tag: `datasheets-{snapshot_date}`
+2. Commit the snapshot to `metadata/api-snapshots/`
+3. Update community content via PRs (previews are generated automatically)
+4. Compile: `python3 compile_datasheets.py {snapshot_date} --api-snapshot metadata/api-snapshots/languagedata-{YYYYMMDD}.json --pretty`
+5. Review the changelog diff (use `--diff` against previous release)
+6. Commit the release JSON
+7. Tag: `datasheets-{snapshot_date}`
+
+Note: `datasheets-latest.json` is updated automatically on merge. Dated release files (`datasheets-{date}.json`) are created manually as part of this workflow.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -14,7 +14,10 @@ Datasheets describe each language dataset in Common Voice. They include informat
 2. Look at `content/_template/` for the directory structure and file list
 3. Look at `content/_example/` for a filled-in reference
 4. Create or edit files under `content/locales/{your-locale-code}/`
-5. Submit a Pull Request
+5. Preview locally (optional): `python3 scripts/preview_datasheets.py -l {your-locale-code}`
+6. Submit a Pull Request -- a preview of your datasheet will be posted automatically as a comment on the PR
+
+Please submit **one PR per locale** so that previews and reviews stay focused.
 
 ### Via Google Form
 

--- a/previews/.gitignore
+++ b/previews/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!.gitkeep

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ keywords = ["common-voice", "datasheets", "speech", "datasets", "mozilla"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",
@@ -21,6 +20,7 @@ classifiers = [
 dependencies = [
     "dotenv>=0.9.9",
     "jinja2>=3.1",
+    "pymarkdownlnt>=0.9",
     "requests>=2.32.5",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,33 @@
 [project]
 name = "cv-datasheets"
-version = "0.0.2"
-description = "Scripts to generate MDC datasheets"
+version = "0.1.0"
+description = "Compile and preview datasheets for Mozilla Common Voice datasets"
 readme = "README.md"
 requires-python = ">=3.12"
+license = "MPL-2.0"
+authors = [
+    { name = "Mozilla Common Voice" },
+]
+keywords = ["common-voice", "datasheets", "speech", "datasets", "mozilla"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Text Processing :: Markup :: Markdown",
+]
 dependencies = [
     "dotenv>=0.9.9",
     "jinja2>=3.1",
     "requests>=2.32.5",
 ]
+
+[project.urls]
+Homepage = "https://github.com/common-voice/cv-datasheets"
+Repository = "https://github.com/common-voice/cv-datasheets"
+Issues = "https://github.com/common-voice/cv-datasheets/issues"
+
+[tool.setuptools]
+packages = []

--- a/scripts/preview_datasheets.py
+++ b/scripts/preview_datasheets.py
@@ -1,0 +1,657 @@
+#!/usr/bin/env python3
+"""preview_datasheets.py
+
+Preview datasheets by compiling directly from the working tree and
+substituting {{KEY}} bundler placeholders with dummy data.
+
+Each locale + modality combination produces a separate file in previews/ like:
+  previews/preview-{locale}-{modality}.md
+
+This lets contributors preview how their community content will look
+in the final datasheet without needing real bundler statistics.
+Works both locally and in GitHub Actions.
+
+Usage:
+    python scripts/preview_datasheets.py --locale CODE [CODE ...]
+    python scripts/preview_datasheets.py --changed
+
+Options:
+    --locale, -l CODE [CODE ...]  One or more locale codes to preview
+    --changed                     Auto-detect changed locales from git diff against main
+
+Examples:
+    python scripts/preview_datasheets.py -l ady
+    python scripts/preview_datasheets.py -l ady kbd es
+    python scripts/preview_datasheets.py --changed
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import re
+import subprocess
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PREVIEWS_DIR = REPO_ROOT / "previews"
+
+# Add repo root to path so we can import from compile_datasheets
+sys.path.insert(0, str(REPO_ROOT))
+import compile_datasheets as compiler  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Dummy data for {{KEY}} placeholders
+# ---------------------------------------------------------------------------
+
+DUMMY_STATS = {
+    "VERSION": "99.0-preview",
+    "CLIPS": "99,999",
+    "HOURS_RECORDED": "1,234.56",
+    "HOURS_VALIDATED": "987.65",
+    "SPEAKERS": "4,567",
+    "TOTAL_SENTENCES": "12,345",
+    "AVG_DURATION_SECS": "5.2",
+    "VALIDATED_CLIPS": "88,888",
+    "INVALIDATED_CLIPS": "5,555",
+    "OTHER_CLIPS": "5,556",
+    "VALIDATED_SENTENCES": "10,000",
+    "UNVALIDATED_SENTENCES": "2,345",
+    "REJECTED_SENTENCES": "500",
+    "PENDING_SENTENCES": "1,845",
+    "REPORTED_SENTENCES": "100",
+}
+
+# -- SCS dummy tables (match real bundler output format) --
+
+DUMMY_GENDER_TABLE_SCS = """\
+| Code | Gender | Clips | Speakers |
+|---|---|---:|---:|
+| male_masculine | Male, masculine | ? | ? |
+| female_feminine | Female, feminine | ? | ? |
+| transgender | Transgender | ? | ? |
+| non-binary | Non-binary | ? | ? |
+| do_not_wish_to_say | Prefer not to say | ? | ? |
+| - | Unspecified | ? | ? |
+
+*Gender declared: ? of ? clips (?%), ? of ? speakers (?%)*"""
+
+DUMMY_AGE_TABLE_SCS = """\
+| Code | Age | Clips | Speakers |
+|---|---|---:|---:|
+| teens | Teens | ? | ? |
+| twenties | Twenties | ? | ? |
+| thirties | Thirties | ? | ? |
+| fourties | Fourties | ? | ? |
+| fifties | Fifties | ? | ? |
+| sixties | Sixties | ? | ? |
+| seventies | Seventies | ? | ? |
+| eighties | Eighties | ? | ? |
+| nineties | Nineties | ? | ? |
+| - | Unspecified | ? | ? |
+
+*Age declared: ? of ? clips (?%), ? of ? speakers (?%)*"""
+
+DUMMY_DATA_SPLITS_TABLE_SCS = """\
+**Clip buckets**
+
+| Bucket | Clips |
+|---|---:|
+| Validated | ? |
+| Invalidated | ? |
+| Other | ? |
+
+**Training splits**
+
+| Split | Clips |
+|---|---:|
+| Train | ? |
+| Dev | ? |
+| Test | ? |
+
+*Training split coverage: ? of ? validated clips (?%)*"""
+
+# -- SPS dummy tables (match real bundler output format) --
+
+DUMMY_DATA_SPLITS_TABLE_SPS = """\
+### Audio clips
+
+| Bucket | Clips | % |
+| --- | ---: | ---: |
+| Transcribed & Validated | ? | ? |
+| Transcribed & Pending | ? | ? |
+| Not transcribed | ? | ? |
+
+### Training splits
+
+| Bucket | Clips | % |
+| --- | ---: | ---: |
+| Train | ? | ? |
+| Dev | ? | ? |
+| Test | ? | ? |
+| Unassigned | ? | ? |
+
+Training split coverage: ? of ? transcribed & validated clips (?%)"""
+
+DUMMY_TRANSCRIPTION_STATS = """\
+### Transcription status
+
+| Bucket | Clips | % |
+| --- | ---: | ---: |
+| Validated | ? | ? |
+| Pending | ? | ? |
+| Edited | ? | ? |"""
+
+# -- SCS text corpus dummy tables --
+
+DUMMY_TEXT_CORPUS_STATS = """\
+**Validated sentences:** ?
+
+| Category | Count |
+|---|---:|
+| Unvalidated sentences | ? |
+| Pending sentences | ? |
+| Rejected sentences | ? |
+| Reported sentences | ? |"""
+
+DUMMY_SOURCES_STATS = """\
+| Source | Sentences |
+|---|---:|
+| ? | ? |"""
+
+DUMMY_SENTENCES_SAMPLE = """\
+1. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+2. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+3. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.
+4. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum.
+5. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia."""
+
+DUMMY_QUESTIONS_SAMPLE = """\
+1. *What is your favorite thing about your city?*
+2. *Can you describe a memorable experience from your childhood?*
+3. *What do you think about the current state of public transportation?*
+4. *How would you explain your job to a five-year-old?*
+5. *What changes would you like to see in your community?*"""
+
+DUMMY_TRANSCRIPTIONS_SAMPLE = """\
+1. *I think the most important thing is that we all work together as a community and support each other.*
+2. *When I was growing up we used to walk to school every morning rain or shine.*
+3. *The bus system here is actually pretty good compared to other cities I have lived in.*
+4. *Well I basically help people fix their computers when things go wrong.*
+5. *I would love to see more green spaces and parks for children to play in.*"""
+
+# Shared auto fields (modality-independent)
+_DUMMY_AUTO_SHARED = {
+    "SENTENCES_SAMPLE": DUMMY_SENTENCES_SAMPLE,
+    "QUESTIONS_SAMPLE": DUMMY_QUESTIONS_SAMPLE,
+    "TRANSCRIPTIONS_SAMPLE": DUMMY_TRANSCRIPTIONS_SAMPLE,
+    "VARIANT_STATS": "",
+    "ACCENT_STATS": "",
+    "TEXT_DOMAIN_STATS": "",
+}
+
+# SCS-specific auto fields
+DUMMY_AUTO_FIELDS_SCS = {
+    **_DUMMY_AUTO_SHARED,
+    "GENDER_TABLE": DUMMY_GENDER_TABLE_SCS,
+    "AGE_TABLE": DUMMY_AGE_TABLE_SCS,
+    "DATA_SPLITS_TABLE": DUMMY_DATA_SPLITS_TABLE_SCS,
+    "TEXT_CORPUS_STATS": DUMMY_TEXT_CORPUS_STATS,
+    "SOURCES_STATS": DUMMY_SOURCES_STATS,
+    "TRANSCRIPTION_STATS": "",
+}
+
+# SPS-specific auto fields
+DUMMY_AUTO_FIELDS_SPS = {
+    **_DUMMY_AUTO_SHARED,
+    "GENDER_TABLE": "",
+    "AGE_TABLE": "",
+    "DATA_SPLITS_TABLE": DUMMY_DATA_SPLITS_TABLE_SPS,
+    "TEXT_CORPUS_STATS": "",
+    "SOURCES_STATS": "",
+    "TRANSCRIPTION_STATS": DUMMY_TRANSCRIPTION_STATS,
+}
+
+
+# ---------------------------------------------------------------------------
+# Post-render cleanup (emulates bundler behaviour)
+# ---------------------------------------------------------------------------
+
+
+def _heading_level(line: str) -> int:
+    """Return the heading level (1-6) or 0 if not a heading."""
+    stripped = line.lstrip()
+    if not stripped.startswith("#"):
+        return 0
+    hashes = 0
+    for ch in stripped:
+        if ch == "#":
+            hashes += 1
+        else:
+            break
+    # Must be followed by a space to be a valid heading
+    if hashes <= 6 and len(stripped) > hashes and stripped[hashes] == " ":
+        return hashes
+    return 0
+
+
+def clean_rendered_markdown(text: str) -> str:
+    """Strip empty sections and excessive blank lines like the bundlers.
+
+    An empty section is a heading followed by only blank lines until the
+    next heading of the same or higher level (or EOF). Empty sections are
+    removed iteratively bottom-up so that parent sections with only empty
+    children are also stripped.
+    """
+    # Iteratively strip empty sections until stable
+    changed = True
+    while changed:
+        changed = False
+        lines = text.split("\n")
+        keep = [True] * len(lines)
+
+        for i, line in enumerate(lines):
+            level = _heading_level(line)
+            if level == 0:
+                continue
+
+            # Scan forward: is there any non-blank, non-heading content
+            # before the next heading of same/higher level (or EOF)?
+            has_content = False
+            j = i + 1
+            while j < len(lines):
+                jlevel = _heading_level(lines[j])
+                if jlevel > 0 and jlevel <= level:
+                    # Hit a same/higher-level heading -> section boundary
+                    break
+                if lines[j].strip():
+                    # Non-blank, non-heading content found
+                    if jlevel > 0:
+                        # It's a sub-heading, keep scanning for real content
+                        j += 1
+                        continue
+                    has_content = True
+                    break
+                j += 1
+
+            if not has_content:
+                # Mark the heading and trailing blank lines for removal
+                keep[i] = False
+                for k in range(i + 1, j):
+                    if lines[k].strip() == "" or _heading_level(lines[k]) > level:
+                        keep[k] = False
+                changed = True
+
+        text = "\n".join(line for line, k in zip(lines, keep) if k)
+
+    # Collapse 3+ consecutive blank lines to 2
+    text = re.sub(r"\n{3,}", "\n\n", text)
+
+    # Ensure single trailing newline
+    text = text.strip() + "\n"
+
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Working tree compilation (single locale)
+# ---------------------------------------------------------------------------
+
+
+CACHED_SNAPSHOT_PATH = PREVIEWS_DIR / ".api-snapshot.json"
+
+# Import fetch helpers from sibling script
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+import fetch_api_metadata as fetcher  # noqa: E402
+
+
+def fetch_api_snapshot_live() -> dict | None:
+    """Fetch a fresh API snapshot from the Common Voice APIs.
+
+    Returns the snapshot dict, or None if the API is unreachable.
+    """
+    try:
+        print("  Fetching from SCS API...", file=sys.stderr)
+        with redirect_stdout(io.StringIO()):
+            scs_raw: list[dict] = fetcher.fetch_json(fetcher.DEFAULT_SCS_URL)  # type: ignore[assignment]
+        print("  Fetching from SPS API...", file=sys.stderr)
+        with redirect_stdout(io.StringIO()):
+            sps_data: dict = fetcher.fetch_json(fetcher.DEFAULT_SPS_URL)  # type: ignore[assignment]
+    except Exception as exc:
+        print(f"  API fetch failed: {exc}", file=sys.stderr)
+        return None
+
+    from datetime import UTC, datetime
+
+    snapshot = fetcher.build_snapshot(
+        scs_raw,
+        sps_data,
+        fetcher.DEFAULT_SCS_URL,
+        fetcher.DEFAULT_SPS_URL,
+        datetime.now(UTC).isoformat(),
+    )
+    return snapshot
+
+
+def load_api_snapshot() -> dict:
+    """Load an API snapshot with fallback chain:
+
+    1. Cached temp file (previews/.api-snapshot.json) if < 24h old
+    2. Fresh fetch from API -> cache to temp file
+    3. Latest committed snapshot in metadata/api-snapshots/
+    4. Empty snapshot (locale codes used as names)
+    """
+    import time
+
+    # 1. Check cached temp file (< 24h old)
+    if CACHED_SNAPSHOT_PATH.exists():
+        age_hours = (time.time() - CACHED_SNAPSHOT_PATH.stat().st_mtime) / 3600
+        if age_hours < 24:
+            print(f"  Using cached snapshot ({age_hours:.1f}h old)", file=sys.stderr)
+            with open(CACHED_SNAPSHOT_PATH, encoding="utf-8") as f:
+                return json.load(f)
+        else:
+            print(f"  Cached snapshot expired ({age_hours:.0f}h old)", file=sys.stderr)
+
+    # 2. Fetch fresh from API
+    snapshot = fetch_api_snapshot_live()
+    if snapshot:
+        PREVIEWS_DIR.mkdir(parents=True, exist_ok=True)
+        with open(CACHED_SNAPSHOT_PATH, "w", encoding="utf-8") as f:
+            json.dump(snapshot, f, ensure_ascii=False)
+        locales = snapshot.get("locales", {})
+        print(f"  Fetched {len(locales)} locales, cached to {CACHED_SNAPSHOT_PATH.name}", file=sys.stderr)
+        return snapshot
+
+    # 3. Fall back to latest committed snapshot
+    snapshots_dir = compiler.METADATA_DIR / "api-snapshots"
+    snapshots = sorted(snapshots_dir.glob("languagedata-*.json"))
+    if snapshots:
+        fallback = snapshots[-1]
+        print(f"  Falling back to committed snapshot: {fallback.name}", file=sys.stderr)
+        with redirect_stdout(io.StringIO()):
+            return compiler.load_api_snapshot(fallback)
+
+    # 4. Empty snapshot (last resort)
+    print("  WARNING: No API snapshot available. Using empty snapshot.", file=sys.stderr)
+    return {"locales": {}, "sps_locales": []}
+
+
+def build_accent_stats_table(api_locale_data: dict | None) -> str:
+    """Build a dummy accent stats table from API predefined_accents."""
+    if not api_locale_data:
+        return ""
+    accents = api_locale_data.get("predefined_accents", [])
+    if not accents:
+        return ""
+
+    lines = ["| Code | Accent | Clips | Speakers |", "|---|---|---:|---:|"]
+    for acc in accents:
+        code = acc.get("code", "")
+        name = acc.get("name", "")
+        lines.append(f"| {code} | {name} | ? | ? |")
+    lines.append("| - | Other | ? | ? |")
+    return "\n".join(lines)
+
+
+def build_variant_stats_table(api_locale_data: dict | None) -> str:
+    """Build a dummy variant stats table from API variants."""
+    if not api_locale_data:
+        return ""
+    variants = api_locale_data.get("variants", [])
+    if not variants:
+        return ""
+
+    lines = ["| Code | Variant | Clips | Speakers |", "|---|---|---:|---:|"]
+    for var in variants:
+        code = var.get("code", "")
+        name = var.get("name", "")
+        lines.append(f"| {code} | {name} | ? | ? |")
+    return "\n".join(lines)
+
+
+def compile_locale_from_tree(
+    locale: str,
+    api_snapshot: dict,
+    template_langs: dict[str, str],
+    funding: dict[str, str],
+    sps_locales: set[str],
+    field_map: dict,
+    templates: dict[str, dict[str, str]],
+) -> list[tuple[str, str, str]]:
+    """Compile a single locale from the working tree.
+
+    Returns list of (locale, modality, rendered_template) for each modality
+    where the locale exists.
+    """
+    api_locales = api_snapshot.get("locales", {})
+    modality_fields_config = field_map.get("modality_fields", {})
+    results: list[tuple[str, str, str]] = []
+
+    for mod_short, modality_dir in compiler.MODALITY_MAP.items():
+        # Check if locale exists in this modality
+        if mod_short == "scs":
+            if locale not in api_locales:
+                continue
+        else:
+            if locale not in sps_locales:
+                continue
+
+        template_lang = template_langs.get(locale, "en")
+        api_locale_data = api_locales.get(locale)
+
+        # Get template
+        mod_templates = templates.get(mod_short, {})
+        template = mod_templates.get(template_lang) or mod_templates.get("en", "")
+        if not template:
+            continue
+
+        # Metadata
+        metadata_native = ""
+        metadata_english = ""
+        if api_locale_data:
+            metadata_native = api_locale_data.get("native_name", "")
+            metadata_english = api_locale_data.get("english_name", "")
+
+        # Load community fields from working tree
+        valid_fields = modality_fields_config.get(modality_dir, [])
+        funder = funding.get(locale, "")
+        community_fields = compiler.load_community_fields(
+            locale,
+            mod_short,
+            modality_dir,
+            template_lang,
+            field_map,
+            valid_fields,
+            funder=funder,
+        )
+
+        # Build substitution map
+        subs: dict[str, str] = {}
+        subs["NATIVE_NAME"] = metadata_native or locale
+        subs["ENGLISH_NAME"] = metadata_english or locale
+        subs["LOCALE"] = locale
+        subs.update(DUMMY_STATS)
+
+        if mod_short == "sps":
+            subs.update(DUMMY_AUTO_FIELDS_SPS)
+        else:
+            subs.update(DUMMY_AUTO_FIELDS_SCS)
+
+        # Generate accent/variant stats tables from API data
+        subs["ACCENT_STATS"] = build_accent_stats_table(api_locale_data)
+        subs["VARIANT_STATS"] = build_variant_stats_table(api_locale_data)
+
+        # Community fields (from working tree)
+        for key, value in community_fields.items():
+            subs[key.upper()] = value
+
+        # Substitute all {{KEY}} placeholders
+        result = template
+        for key, value in subs.items():
+            result = result.replace("{{" + key + "}}", value)
+
+        # Replace any remaining {{KEY}} with a placeholder notice
+        result = re.sub(r"\{\{([A-Z_]+)\}\}", r"*(placeholder: \1)*", result)
+
+        # Post-render cleanup: strip empty sections, collapse blank lines
+        result = clean_rendered_markdown(result)
+
+        # Add disclaimer at the top
+        from datetime import UTC, datetime
+
+        timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
+        disclaimer = (
+            f"> **Preview** - This is a preview with dummy numeric data. "
+            f"Tables marked with `?` will be filled by the bundler at release time. "
+            f"Generated: {timestamp}\n"
+        )
+        result = disclaimer + "\n" + result
+
+        results.append((locale, mod_short, result))
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Changed locale detection
+# ---------------------------------------------------------------------------
+
+
+def detect_changed_locales() -> list[tuple[str, str]]:
+    """Detect changed locales from git diff against main.
+
+    Returns list of (locale, modality_short) tuples.
+    """
+    try:
+        diff = subprocess.run(
+            ["git", "diff", "--name-only", "main", "--", "content/locales/"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+
+    modality_dir_map = {"scripted": "scs", "spontaneous": "sps", "shared": None}
+    results: set[tuple[str, str]] = set()
+
+    for line in diff.stdout.strip().splitlines():
+        # content/locales/{locale}/{modality_dir}/...
+        parts = Path(line).parts
+        if len(parts) < 4 or parts[0] != "content" or parts[1] != "locales":
+            continue
+        locale = parts[2]
+        modality_dir = parts[3]
+        mod_short = modality_dir_map.get(modality_dir)
+        if mod_short:
+            results.add((locale, mod_short))
+        elif modality_dir == "shared":
+            # Shared files affect both modalities
+            results.add((locale, "scs"))
+            results.add((locale, "sps"))
+
+    return sorted(results)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """
+    Parses command-line arguments to preview rendered templates for
+    specified or changed locales, loading metadata and writing output files
+    to the previews directory. Displays help or error messages as needed.
+    """
+    args = sys.argv[1:]
+
+    if not args or args[0] in ("-h", "--help"):
+        print((__doc__ or "").strip())
+        sys.exit(0)
+
+    locales: list[str] = []
+    changed = False
+
+    i = 0
+    while i < len(args):
+        if args[i] in ("--locale", "-l") and i + 1 < len(args):
+            i += 1
+            # Consume all following args that don't start with --
+            while i < len(args) and not args[i].startswith("-"):
+                locales.append(args[i])
+                i += 1
+        elif args[i] == "--changed":
+            changed = True
+            i += 1
+        else:
+            print(f"Unknown option: {args[i]}", file=sys.stderr)
+            sys.exit(1)
+
+    # Load shared data once
+    print("Loading API snapshot...", file=sys.stderr)
+    api_snapshot = load_api_snapshot()
+    with redirect_stdout(io.StringIO()):
+        template_langs, funding, sps_locales = compiler.load_metadata(api_snapshot)
+
+    with open(compiler.FIELD_MAP_PATH, encoding="utf-8") as f:
+        field_map = json.load(f)
+
+    print("Rendering templates...", file=sys.stderr)
+    with redirect_stdout(io.StringIO()):
+        templates = compiler.render_templates(field_map)
+
+    # Determine what to preview
+    locales_to_preview: list[str] = []
+
+    if changed:
+        changed_pairs = detect_changed_locales()
+        if not changed_pairs:
+            print("No changed locales detected (compared to main).")
+            sys.exit(0)
+        # Deduplicate locale codes (compile_locale_from_tree handles modalities)
+        locales_to_preview = list(dict.fromkeys(loc for loc, _ in changed_pairs))
+        print(
+            f"\nDetected {len(locales_to_preview)} changed locale(s): "
+            f"{', '.join(locales_to_preview)}",
+            file=sys.stderr,
+        )
+    elif locales:
+        locales_to_preview = locales
+    else:
+        print("Error: Specify --locale CODE [CODE ...] or --changed.", file=sys.stderr)
+        sys.exit(1)
+
+    # Compile and write previews
+    PREVIEWS_DIR.mkdir(parents=True, exist_ok=True)
+    total = 0
+
+    print(file=sys.stderr)
+    for loc in locales_to_preview:
+        results = compile_locale_from_tree(
+            loc,
+            api_snapshot,
+            template_langs,
+            funding,
+            sps_locales,
+            field_map,
+            templates,
+        )
+        if not results:
+            print(f"  {loc}: not found in any modality, skipping", file=sys.stderr)
+            continue
+        for _, mod, rendered in results:
+            filename = f"preview-{loc}-{mod}.md"
+            filepath = PREVIEWS_DIR / filename
+            filepath.write_text(rendered + "\n", encoding="utf-8")
+            print(f"  {loc} ({mod.upper()}): {filepath}", file=sys.stderr)
+            total += 1
+
+    print(f"\n{total} preview(s) written to {PREVIEWS_DIR}/", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/preview_datasheets.py
+++ b/scripts/preview_datasheets.py
@@ -499,17 +499,6 @@ def compile_locale_from_tree(
         # Post-render cleanup: strip empty sections, collapse blank lines
         result = clean_rendered_markdown(result)
 
-        # Add disclaimer at the top
-        from datetime import UTC, datetime
-
-        timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
-        disclaimer = (
-            f"> **Preview** - This is a preview with dummy numeric data. "
-            f"Tables marked with `?` will be filled by the bundler at release time. "
-            f"Generated: {timestamp}\n"
-        )
-        result = disclaimer + "\n" + result
-
         results.append((locale, mod_short, result))
 
     return results

--- a/scripts/preview_datasheets.py
+++ b/scripts/preview_datasheets.py
@@ -520,40 +520,78 @@ def compile_locale_from_tree(
 # ---------------------------------------------------------------------------
 
 
-def detect_changed_locales() -> list[tuple[str, str]]:
-    """Detect changed locales from git diff against main.
-
-    Returns list of (locale, modality_short) tuples.
-    """
+def _git_diff_names(path: str = "") -> list[str]:
+    """Get changed file names from git diff against main."""
+    cmd = ["git", "diff", "--name-only", "main"]
+    if path:
+        cmd += ["--", path]
     try:
-        diff = subprocess.run(
-            ["git", "diff", "--name-only", "main", "--", "content/locales/"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        return [l for l in result.stdout.strip().splitlines() if l]
     except (subprocess.CalledProcessError, FileNotFoundError):
         return []
 
-    modality_dir_map = {"scripted": "scs", "spontaneous": "sps", "shared": None}
-    results: set[tuple[str, str]] = set()
 
-    for line in diff.stdout.strip().splitlines():
+def _detect_template_lang_changes() -> set[str]:
+    """Detect locales affected by template-languages.json changes.
+
+    Compares current vs main version of the file and returns locale codes
+    whose template language mapping was added, removed, or changed.
+    """
+    changed_files = _git_diff_names("metadata/template-languages.json")
+    if not changed_files:
+        return set()
+
+    # Load current version
+    current: dict[str, str] = {}
+    tl_path = compiler.TEMPLATE_LANGS_PATH
+    if tl_path.exists():
+        with open(tl_path, encoding="utf-8") as f:
+            current = json.load(f)
+        current.pop("_comment", None)
+
+    # Load main version
+    previous: dict[str, str] = {}
+    try:
+        result = subprocess.run(
+            ["git", "show", "main:metadata/template-languages.json"],
+            capture_output=True, text=True, check=True,
+        )
+        previous = json.load(__import__("io").StringIO(result.stdout))
+        previous.pop("_comment", None)
+    except (subprocess.CalledProcessError, json.JSONDecodeError):
+        pass
+
+    # Find locales with changed mappings
+    all_locales = set(current.keys()) | set(previous.keys())
+    changed = set()
+    for loc in all_locales:
+        if current.get(loc) != previous.get(loc):
+            changed.add(loc)
+
+    return changed
+
+
+def detect_changed_locales() -> tuple[list[str], list[str]]:
+    """Detect changed locales from git diff against main.
+
+    Returns:
+        (content_locales, metadata_locales) - deduplicated locale code lists.
+        content_locales: locales with changed content files.
+        metadata_locales: locales affected by template-languages.json changes.
+    """
+    content_locales: set[str] = set()
+
+    for line in _git_diff_names("content/locales/"):
         # content/locales/{locale}/{modality_dir}/...
         parts = Path(line).parts
         if len(parts) < 4 or parts[0] != "content" or parts[1] != "locales":
             continue
-        locale = parts[2]
-        modality_dir = parts[3]
-        mod_short = modality_dir_map.get(modality_dir)
-        if mod_short:
-            results.add((locale, mod_short))
-        elif modality_dir == "shared":
-            # Shared files affect both modalities
-            results.add((locale, "scs"))
-            results.add((locale, "sps"))
+        content_locales.add(parts[2])
 
-    return sorted(results)
+    metadata_locales = _detect_template_lang_changes()
+
+    return sorted(content_locales), sorted(metadata_locales)
 
 
 # ---------------------------------------------------------------------------
@@ -608,17 +646,23 @@ def main() -> None:
     locales_to_preview: list[str] = []
 
     if changed:
-        changed_pairs = detect_changed_locales()
-        if not changed_pairs:
+        content_locales, metadata_locales = detect_changed_locales()
+        # Merge both lists, deduplicated
+        all_changed = list(dict.fromkeys(content_locales + metadata_locales))
+        if not all_changed:
             print("No changed locales detected (compared to main).")
             sys.exit(0)
-        # Deduplicate locale codes (compile_locale_from_tree handles modalities)
-        locales_to_preview = list(dict.fromkeys(loc for loc, _ in changed_pairs))
-        print(
-            f"\nDetected {len(locales_to_preview)} changed locale(s): "
-            f"{', '.join(locales_to_preview)}",
-            file=sys.stderr,
-        )
+        locales_to_preview = all_changed
+        if content_locales:
+            print(
+                f"\nContent changes: {', '.join(content_locales)}",
+                file=sys.stderr,
+            )
+        if metadata_locales:
+            print(
+                f"Template language remapped: {', '.join(metadata_locales)}",
+                file=sys.stderr,
+            )
     elif locales:
         locales_to_preview = locales
     else:

--- a/scripts/preview_datasheets.py
+++ b/scripts/preview_datasheets.py
@@ -557,7 +557,7 @@ def _detect_template_lang_changes() -> set[str]:
             ["git", "show", "main:metadata/template-languages.json"],
             capture_output=True, text=True, check=True,
         )
-        previous = json.load(__import__("io").StringIO(result.stdout))
+        previous = json.load(io.StringIO(result.stdout))
         previous.pop("_comment", None)
     except (subprocess.CalledProcessError, json.JSONDecodeError):
         pass


### PR DESCRIPTION
This PR adds a datasheet preview system and CI/CD automation.

- Contributors can now preview how their community content will render in the final datasheet locally
- Previews will render automatically in a PR comments (reused)
- Ddatasheets are auto-compiled on merge to `main`.
- +Doc updates
- `pyproject.toml` metadata improvements

**Changes:**
- New `scripts/preview_datasheets.py` script that compiles locale datasheets from the working tree with dummy statistics, supporting both manual locale specification and git-diff-based auto-detection.
- Two new GitHub Actions workflows:
  - `preview.yml` posts rendered preview comments on PRs
  -  `compile-latest.yml` auto-compiles `releases/datasheets-latest.json` on merge to `main`.
